### PR TITLE
Fix build exclusions in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ build: clean
 	mkdir -p build
 
 build/putioroku.zip: build
-	zip -r -9 build/putioroku.zip . --exclude build
+	zip -r -9 build/putioroku.zip . -x "build*" ".git*"
 
 clean:
 	rm -rf build


### PR DESCRIPTION
This became apparent when a zipped build still included the `build` directory. While the directory should always be empty (the default `make` task clears the build folder before zipping), it does include the .git folder, which will become larger as the repository grows.

At current revision, the reduction in the build size is about **80%**:

```
With .git folder: ~325kb
Without .git folder: ~65kb
```

Note that this while this branch is tracking upstream, the rest of my fork is quite different. Thought this would be a nice inclusion though :) 
