### PR TITLE
feat(roku): add live deep-link tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,18 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: .node-version
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          cache: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Verify repository
         run: make verify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,19 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: .node-version
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          cache: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Verify repository
         run: make verify
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 .env
+.local/
 node_modules/
 .sst/
+build/
+out/
 *.pkg
 *.zip
 dist/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,13 +17,19 @@
 - `make verify`
 - `make smoke`
 - `make live-test`
+- `make live-test-control`
+- `make live-test-press KEYS="Back Info"`
+- `make live-test-deeplink CONTENT_ID=1587417579`
 - `make live-test-launch`
 - `make live-test-install`
 - `make console`
 - `make artifact`
 - `make run`
+- `make check-roku-live`
 - `make check-roku-dev-target`
+- `pnpm check:live`
 - `pnpm check:roku`
+- `pnpm roku:live control-smoke`
 - `pnpm format:roku`
 
 ## Rules
@@ -38,6 +44,7 @@
 - `.env.example` must stay sanitized and safe to publish
 - `make verify` runs the Node-based Roku static checks and builds a fresh ZIP
 - Roku static checks are configured through `bsconfig.json` and `bslint.json`
+- Headless Roku control uses ECP through `scripts/roku-live-test.ts`
 
 ## CI
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,22 +3,28 @@
 ## Repo
 
 - Standalone Roku app repository for put.io
-- Stack: BrightScript and SceneGraph
+- Stack: BrightScript, SceneGraph, BrighterScript tooling
 
 ## Start Here
 
 - [Overview](./README.md)
 - [Contributing](./CONTRIBUTING.md)
+- [Live Test](./live-test/README.md)
 - [Security](./SECURITY.md)
 
 ## Commands
 
 - `make verify`
+- `make smoke`
+- `make live-test`
+- `make live-test-launch`
+- `make live-test-install`
+- `make console`
 - `make artifact`
 - `make run`
 - `make check-roku-dev-target`
-- `make pkg`
-- `make app-pkg`
+- `pnpm check:roku`
+- `pnpm format:roku`
 
 ## Rules
 
@@ -30,7 +36,8 @@
 
 - Local overrides flow through optional `.env`
 - `.env.example` must stay sanitized and safe to publish
-- `make verify` always builds a fresh zip and runs the desktop BrightScript checker when that tool is available locally
+- `make verify` runs the Node-based Roku static checks and builds a fresh ZIP
+- Roku static checks are configured through `bsconfig.json` and `bslint.json`
 
 ## CI
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@
 - `make live-test`
 - `make live-test-control`
 - `make live-test-press KEYS="Back Info"`
-- `make live-test-deeplink CONTENT_ID=1587417579`
+- `make live-test-deeplink CONTENT_ID=<file-id>`
 - `make live-test-launch`
 - `make live-test-install`
 - `make console`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,10 +50,14 @@ make run
 Useful device-debug commands:
 
 - `make smoke` runs the standard static checks and builds a fresh ZIP
+- `pnpm check:live` type-checks the headless Roku ECP controller
 - `pnpm check:roku` runs the BrighterScript compiler diagnostics and `bslint`
 - `pnpm format:roku` checks BrightScript/BrighterScript formatting
 - `make check-roku-dev-target` checks that the Roku developer endpoint is reachable
 - `make live-test` runs read-only device reachability and state checks
+- `make live-test-control` launches the sideloaded app, sends remote keypresses over ECP, and asserts the dev app stays active
+- `make live-test-press KEYS="Back Info"` sends explicit remote keypresses over ECP
+- `make live-test-deeplink CONTENT_ID=<file-id> [MEDIA_TYPE=movie]` launches the sideloaded app through Roku deep linking
 - `make live-test-launch` opens the installed developer app and reports active app state
 - `make live-test-install` builds, reinstalls, and launches this checkout on the device
 - `make launch` opens the sideloaded developer app on the configured Roku

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,8 @@ Prerequisites:
 - `make`
 - `zip`
 - `curl`
+- Node.js from `.node-version`
+- `pnpm`
 
 Optional local overrides live in `.env`:
 
@@ -22,6 +24,12 @@ Supported variables:
 - `ROKU_DEV_PASSWORD` for the Roku Developer Mode password when authenticated installs are required
 
 If you need help enabling Developer Mode on the device itself, use the [Sideloading guide](./docs/SIDELOADING.md)
+
+Install the Node-based Roku toolchain:
+
+```bash
+pnpm install --frozen-lockfile
+```
 
 ## Run Locally
 
@@ -39,6 +47,22 @@ make run
 
 `make run` removes the previously installed developer app, builds a fresh ZIP, validates the target, and reinstalls the app.
 
+Useful device-debug commands:
+
+- `make smoke` runs the standard static checks and builds a fresh ZIP
+- `pnpm check:roku` runs the BrighterScript compiler diagnostics and `bslint`
+- `pnpm format:roku` checks BrightScript/BrighterScript formatting
+- `make check-roku-dev-target` checks that the Roku developer endpoint is reachable
+- `make live-test` runs read-only device reachability and state checks
+- `make live-test-launch` opens the installed developer app and reports active app state
+- `make live-test-install` builds, reinstalls, and launches this checkout on the device
+- `make launch` opens the sideloaded developer app on the configured Roku
+- `make active-app` prints the currently active Roku app from ECP
+- `make device-info` prints the configured Roku device metadata from ECP
+- `make console` attaches to the BrightScript debug console on port `8085`
+
+See [Live Test](./live-test/README.md) for the hardware-backed debugging flow.
+
 ## Validation
 
 Run the standard repo verification before opening or updating a pull request:
@@ -53,7 +77,7 @@ Build the release-style ZIP used by automation:
 make artifact
 ```
 
-`make verify` always creates a fresh app ZIP. When the local BrightScript desktop checker is available, it also runs `make check` as part of verification.
+`make verify` always runs the Node-based Roku static checks and creates a fresh app ZIP.
 
 ## Development Notes
 

--- a/Makefile
+++ b/Makefile
@@ -1,699 +1,175 @@
 -include .env
 
-APPNAME = put.io
+APP_NAME := put.io
 VERSION = 2.8.5
-ARTIFACT_NAME = putio-roku-v2.zip
+ARTIFACT_NAME := putio-roku-v2.zip
 
-ZIP_EXCLUDE= -x \*.pkg -x .gitignore -x README.md -x CONTRIBUTING.md -x SECURITY.md -x AGENTS.md -x CLAUDE.md -x LICENSE -x .env* -x .git\* -x .github\* -x docs\* -x design\* -x keys\* -x dist\* -x node_modules\* -x package.json -x pnpm-lock.yaml -x sst.config.ts -x tsconfig.json -x infra\* -x scripts\* -x .node-version -x .sst\* -x .releaserc.json -x \*/.\*
+DIST_DIR := dist
+ZIP_DIR := $(DIST_DIR)/apps
+TMP_DIR := $(DIST_DIR)/tmp
+APP_ZIP_FILE := $(ZIP_DIR)/$(APP_NAME).zip
+ARTIFACT_ZIP_FILE := $(ZIP_DIR)/$(ARTIFACT_NAME)
+ROKU_RESPONSE_FILE := $(TMP_DIR)/roku-response.html
+ROKU_APP_FILES := $(shell find manifest source components images -type f ! -name '*~' 2>/dev/null)
 
-#########################################################################
-# Makefile common usage:
-# > make
-# > make run
-# > make install
-# > make remove
-#
-# Makefile less common usage:
-# > make art-opt
-# > make pkg
-# > make install_native
-# > make remove_native
-# > make tr
-#
-# By default, ZIP_EXCLUDE will exclude -x \*.pkg -x storeassets\* -x keys\* -x .\*
-# If you define ZIP_EXCLUDE in your Makefile, it will override the default setting.
-#
-# To exclude different files from being added to the zipfile during packaging
-# include a line like this:ZIP_EXCLUDE= -x keys\*
-# that will exclude any file who's name begins with 'keys'
-# to exclude using more than one pattern use additional '-x <pattern>' arguments
-# ZIP_EXCLUDE= -x \*.pkg -x storeassets\*
-#
-# If you want to add additional files to the default ZIP_EXCLUDE use
-# ZIP_EXCLUDE_LOCAL
-#
-# Important Notes:
-# To use the "run", "install" and "remove" targets to install your
-# application directly from the shell, you must do the following:
-#
-# 1) Make sure that you have the curl command line executable in your path
-# 2) Set the variable ROKU_DEV_TARGET in your environment to the IP
-#    address of your Roku box. (e.g. export ROKU_DEV_TARGET=192.168.1.1.
-##########################################################################
+ROKU_DEV_CONSOLE_PORT ?= 8085
 
-# improve performance and simplify Makefile debugging by omitting
-# default language rules that don't apply to this environment.
+ifdef ROKU_DEV_PASSWORD
+	ROKU_DEV_USERPASS := rokudev:$(ROKU_DEV_PASSWORD)
+else
+	ROKU_DEV_USERPASS := rokudev
+endif
+
 MAKEFLAGS += --no-builtin-rules
 .SUFFIXES:
+.DEFAULT_GOAL := build
 
-HOST_OS := unknown
-UNAME_S := $(shell uname -s)
-ifeq ($(UNAME_S),Darwin)
-	HOST_OS := macos
-else ifeq ($(UNAME_S),Linux)
-	HOST_OS := linux
-else ifneq (,$(findstring CYGWIN,$(UNAME_S)))
-	HOST_OS := cygwin
-endif
+.PHONY: build
+build: $(APP_ZIP_FILE)
 
-IS_TEAMCITY_BUILD ?=
-ifneq ($(TEAMCITY_BUILDCONF_NAME),)
-IS_TEAMCITY_BUILD := true
-endif
+.PHONY: $(APP_NAME)
+$(APP_NAME): build
 
-# get the root directory in absolute form, so that current directory
-# can be changed during the make if needed.
-APPS_ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+$(APP_ZIP_FILE): $(ROKU_APP_FILES)
+	@echo "*** Creating $(APP_NAME).zip ***"
+	@rm -f "$(APP_ZIP_FILE)"
+	@mkdir -p "$(ZIP_DIR)"
+	@find images components -type f -name '*.png' -print | zip -0 "$(APP_ZIP_FILE)" -@
+	@find manifest source components images -type f ! -name '*.png' ! -name '*~' -print | zip -9 "$(APP_ZIP_FILE)" -@
+	@test -f "$(APP_ZIP_FILE)"
+	@echo "*** Packaging $(APP_NAME) complete ***"
 
-# the current directory is the app root directory
-SOURCEDIR := .
-
-DISTREL := $(APPS_ROOT_DIR)/dist
-COMMONREL := $(APPS_ROOT_DIR)/common
-
-ZIPREL := $(DISTREL)/apps
-PKGREL := $(DISTREL)/packages
-CHECK_TMP_DIR := $(DISTREL)/tmp-check
-
-DATE_TIME := $(shell date +%F-%T)
-
-APP_ZIP_FILE := $(ZIPREL)/$(APPNAME).zip
-APP_PKG_FILE := $(PKGREL)/$(APPNAME)_$(DATE_TIME).pkg
-ARTIFACT_ZIP_FILE := $(ZIPREL)/$(ARTIFACT_NAME)
-
-# these variables are only used for the .pkg file version tagging.
-APP_NAME := $(APPNAME)
-APP_VERSION := $(VERSION)
-ifeq ($(IS_TEAMCITY_BUILD),true)
-APP_NAME    := $(subst /,-,$(TEAMCITY_BUILDCONF_NAME))
-APP_VERSION := $(BUILD_NUMBER)
-endif
-
-APPSOURCEDIR := $(SOURCEDIR)/source
-IMPORTFILES := $(foreach f,$(IMPORTS),$(COMMONREL)/$f.brs)
-IMPORTCLEANUP := $(foreach f,$(IMPORTS),$(APPSOURCEDIR)/$f.brs)
-
-# ROKU_NATIVE_DEV must be set in the calling environment to
-# the firmware native-build src directory
-NATIVE_DIST_DIR := $(ROKU_NATIVE_DEV)/dist
-#
-NATIVE_DEV_REL  := $(NATIVE_DIST_DIR)/rootfs/Linux86_dev.OBJ/root/nvram/incoming
-NATIVE_DEV_PKG  := $(NATIVE_DEV_REL)/dev.zip
-NATIVE_PLETHORA := $(NATIVE_DIST_DIR)/application/Linux86_dev.OBJ/root/bin/plethora
-NATIVE_TICKLER  := $(NATIVE_PLETHORA) tickle-plugin-installer
-
-# only Linux host is supported for these tools currently
-APPS_TOOLS_DIR    := $(APPS_ROOT_DIR)/tools/$(HOST_OS)/bin
-
-APP_PACKAGE_TOOL  := $(APPS_TOOLS_DIR)/app-package
-MAKE_TR_TOOL      := $(APPS_TOOLS_DIR)/maketr
-BRIGHTSCRIPT_TOOL := $(APPS_TOOLS_DIR)/brightscript
-
-# if building from a firmware tree, use the BrightScript libraries from there
-ifneq (,$(wildcard $(APPS_ROOT_DIR)/../3rdParty/brightscript/Scripts/LibCore/.))
-BRIGHTSCRIPT_LIBS_DIR ?= $(APPS_ROOT_DIR)/../3rdParty/brightscript/Scripts/LibCore
-endif
-# else use the reference libraries from the tools directory.
-BRIGHTSCRIPT_LIBS_DIR ?= $(APPS_ROOT_DIR)/tools/brightscript/Scripts/LibCore
-
-APP_KEY_PASS_TMP := /tmp/app_key_pass
-DEV_SERVER_TMP_FILE := /tmp/dev_server_out
-
-# The developer password that was set on the player is required for
-# plugin_install operations on modern versions of firmware.
-# It may be pre-specified in the ROKU_DEV_PASSWORD environment variable on entry,
-# otherwise the make will stop and prompt the user to enter it when needed.
-ifdef ROKU_DEV_PASSWORD
-	USERPASS := rokudev:$(ROKU_DEV_PASSWORD)
-else
-	USERPASS := rokudev
-endif
-
-ifeq ($(HOST_OS),macos)
-	# Mac doesn't support these args
-	CP_ARGS =
-else
-	CP_ARGS = --preserve=ownership,timestamps --no-preserve=mode
-endif
-
-# For a quick ping, we want the command to return success as soon as possible,
-# and a timeout failure in no more than a second or two.
-ifeq ($(HOST_OS),cygwin)
-	# This assumes that the Windows ping command is used, not cygwin's.
-	QUICK_PING_ARGS = -n 1 -w 1000
-else # Linux
-	QUICK_PING_ARGS = -c 1 -w 1
-endif
-
-ifndef ZIP_EXCLUDE
-	ZIP_EXCLUDE= -x \*.pkg -x storeassets\* -x keys\* -x \*/.\* $(ZIP_EXCLUDE_LOCAL)
-endif
-
-# -------------------------------------------------------------------------
-# $(APPNAME): the default target is to create the zip file for the app.
-# This contains the set of files that are to be deployed on a Roku.
-# -------------------------------------------------------------------------
-.PHONY: $(APPNAME)
-$(APPNAME): manifest
-	@echo "*** Creating $(APPNAME).zip ***"
-
-	@echo "  >> removing old application zip $(APP_ZIP_FILE)"
-	@if [ -e "$(APP_ZIP_FILE)" ]; then \
-		rm -f $(APP_ZIP_FILE); \
-	fi
-
-	@echo "  >> creating destination directory $(ZIPREL)"
-	@if [ ! -d $(ZIPREL) ]; then \
-		mkdir -p $(ZIPREL); \
-	fi
-
-	@echo "  >> setting directory permissions for $(ZIPREL)"
-	@if [ ! -w $(ZIPREL) ]; then \
-		chmod 755 $(ZIPREL); \
-	fi
-
-	@echo "  >> copying imports"
-	@if [ "$(IMPORTFILES)" ]; then \
-		mkdir $(APPSOURCEDIR)/common; \
-		cp -f $(CP_ARGS) -v $(IMPORTFILES) $(APPSOURCEDIR)/common/; \
-	fi \
-
-# zip .png files without compression
-# do not zip up Makefiles, or any files ending with '~'
-	@echo "  >> creating application zip $(APP_ZIP_FILE)"
-	@if [ -d $(SOURCEDIR) ]; then \
-		(zip -0 -r "$(APP_ZIP_FILE)" . -i \*.png $(ZIP_EXCLUDE)); \
-		(zip -9 -r "$(APP_ZIP_FILE)" . -x \*~ -x \*.png -x Makefile $(ZIP_EXCLUDE)); \
-	else \
-		echo "Source for $(APPNAME) not found at $(SOURCEDIR)"; \
-	fi
-
-	@if [ "$(IMPORTCLEANUP)" ]; then \
-		echo "  >> deleting imports";\
-		rm -r -f $(APPSOURCEDIR)/common; \
-	fi \
-
-	@echo "*** packaging $(APPNAME) complete ***"
-
-# If DISTDIR is not empty then copy the zip package to the DISTDIR.
-# Note that this is used by the firmware build, to build applications that are
-# embedded in the firmware software image, such as the built-in screensaver.
-# For those cases, the Netflix/Makefile calls this makefile for each app
-# with DISTDIR and DISTZIP set to the target directory and base filename
-# respectively.
-	@if [ $(DISTDIR) ]; then \
-		rm -f $(DISTDIR)/$(DISTZIP).zip; \
-		mkdir -p $(DISTDIR); \
-		cp -f --preserve=ownership,timestamps --no-preserve=mode \
-			$(APP_ZIP_FILE) $(DISTDIR)/$(DISTZIP).zip; \
-	fi
-
-# -------------------------------------------------------------------------
-# clean: remove any build output for the app.
-# -------------------------------------------------------------------------
 .PHONY: clean
 clean:
-	rm -f $(APP_ZIP_FILE)
-	rm -f $(ARTIFACT_ZIP_FILE)
-# FIXME: we should use a canonical output file name, rather than having
-# the date-time stamp in the output file name.
-#	rm -f $(APP_PKG_FILE)
-	rm -f $(PKGREL)/$(APPNAME)_*.pkg
+	rm -rf build
+	rm -rf "$(TMP_DIR)"
+	rm -f "$(APP_ZIP_FILE)"
+	rm -f "$(ARTIFACT_ZIP_FILE)"
 
-# -------------------------------------------------------------------------
-# verify: create a fresh zip and run the repo-native BrightScript check when
-# the desktop tool is available.
-# -------------------------------------------------------------------------
+.PHONY: check-roku-static
+check-roku-static:
+	@echo "*** Running Roku static checks ***"
+	pnpm exec bslint --project bsconfig.json
+
 .PHONY: verify
-verify: clean check
+verify: clean check-roku-static build
 	@test -f "$(APP_ZIP_FILE)"
 
-# -------------------------------------------------------------------------
-# artifact: produce the release-style zip name used by automation.
-# -------------------------------------------------------------------------
+.PHONY: smoke
+smoke: verify
+
 .PHONY: artifact
-artifact: clean $(APPNAME)
+artifact: verify
 	@mv "$(APP_ZIP_FILE)" "$(ARTIFACT_ZIP_FILE)"
 	@test -f "$(ARTIFACT_ZIP_FILE)"
 
-# -------------------------------------------------------------------------
-# clobber: remove any build output for the app.
-# -------------------------------------------------------------------------
-.PHONY: clobber
-clobber: clean
-
-# -------------------------------------------------------------------------
-# dist-clean: remove the dist directory for the sandbox.
-# -------------------------------------------------------------------------
-.PHONY: dist-clean
-dist-clean:
-	rm -rf $(DISTREL)/*
-
-# -------------------------------------------------------------------------
-# CHECK_OPTIONS: this is used to specify configurable options, such
-# as which version of the BrightScript library sources should be used
-# to compile the app.
-# -------------------------------------------------------------------------
-CHECK_OPTIONS =
-ifneq (,$(wildcard $(BRIGHTSCRIPT_LIBS_DIR)/.))
-CHECK_OPTIONS += -lib $(BRIGHTSCRIPT_LIBS_DIR)
-endif
-
-# -------------------------------------------------------------------------
-# check: run the desktop BrightScript compiler/check tool on the
-# application.
-# You can bypass checking on the application by setting
-# APP_CHECK_DISABLED=true in the app's Makefile or in the environment.
-# -------------------------------------------------------------------------
-.PHONY: check
-check: $(APPNAME)
-ifeq ($(APP_CHECK_DISABLED),true)
-ifeq ($(IS_TEAMCITY_BUILD),true)
-	@echo "*** Warning: application check skipped ***"
-endif
-else
-ifeq ($(wildcard $(BRIGHTSCRIPT_TOOL)),)
-	@echo "*** Note: application check not available ***"
-else
-	@echo "*** Checking application ***"
-	rm -rf $(CHECK_TMP_DIR)
-	mkdir -p $(CHECK_TMP_DIR)
-	unzip -q $(APP_ZIP_FILE) -d $(CHECK_TMP_DIR)
-	$(BRIGHTSCRIPT_TOOL) check \
-		$(CHECK_OPTIONS) \
-		$(CHECK_TMP_DIR)
-	rm -rf $(CHECK_TMP_DIR)
-endif
-endif
-
-# -------------------------------------------------------------------------
-# check-strict: run the desktop BrightScript compiler/check tool on the
-# application using strict mode.
-# -------------------------------------------------------------------------
-.PHONY: check-strict
-check-strict: $(APPNAME)
-	@echo "*** Checking application (strict) ***"
-	rm -rf $(CHECK_TMP_DIR)
-	mkdir -p $(CHECK_TMP_DIR)
-	unzip -q $(APP_ZIP_FILE) -d $(CHECK_TMP_DIR)
-	$(BRIGHTSCRIPT_TOOL) check -strict \
-		$(CHECK_OPTIONS) \
-		$(CHECK_TMP_DIR)
-	rm -rf $(CHECK_TMP_DIR)
-
-# -------------------------------------------------------------------------
-# GET_FRIENDLY_NAME_FROM_DD is used to extract the Roku device ID
-# from the ECP device description XML response.
-# -------------------------------------------------------------------------
-define GET_FRIENDLY_NAME_FROM_DD
-	cat $(DEV_SERVER_TMP_FILE) | \
-		grep -o "<friendlyName>.*</friendlyName>" | \
-		sed "s|<friendlyName>||" | \
-		sed "s|</friendlyName>||"
-endef
-
-# -------------------------------------------------------------------------
-# CHECK_ROKU_DEV_TARGET is used to check if ROKU_DEV_TARGET refers a
-# Roku device on the network that has an enabled developer web server.
-# If the target doesn't exist or doesn't have an enabled web server
-# the connection should fail.
-# -------------------------------------------------------------------------
-define CHECK_ROKU_DEV_TARGET
-	if [ -z "$(ROKU_DEV_TARGET)" ]; then \
+.PHONY: check-roku-dev-target
+check-roku-dev-target:
+	@if [ -z "$(ROKU_DEV_TARGET)" ]; then \
 		echo "ERROR: ROKU_DEV_TARGET is not set."; \
 		exit 1; \
 	fi
-	echo "Checking dev server at $(ROKU_DEV_TARGET)..."
+	@echo "Checking dev server at $(ROKU_DEV_TARGET)..."
+	@mkdir -p "$(TMP_DIR)"
+	@curl --connect-timeout 2 --max-time 4 --silent --show-error \
+		--output "$(ROKU_RESPONSE_FILE)" \
+		http://$(ROKU_DEV_TARGET):8060/query/device-info
+	@ROKU_DEV_NAME=$$(sed -n 's:.*<friendly-device-name>\(.*\)</friendly-device-name>.*:\1:p' "$(ROKU_RESPONSE_FILE)"); \
+		if [ -z "$$ROKU_DEV_NAME" ]; then \
+			ROKU_DEV_NAME=$$(sed -n 's:.*<friendlyName>\(.*\)</friendlyName>.*:\1:p' "$(ROKU_RESPONSE_FILE)"); \
+		fi; \
+		echo "Device reports as \"$${ROKU_DEV_NAME:-unknown}\"."
+	@curl --connect-timeout 2 --max-time 4 --silent --show-error \
+		--output /dev/null \
+		http://$(ROKU_DEV_TARGET)
+	@echo "Dev server is ready."
 
-	# # first check if the device is on the network via a quick ping
-	# ping $(QUICK_PING_ARGS) $(ROKU_DEV_TARGET) &> $(DEV_SERVER_TMP_FILE) || \
-	# 	( \
-	# 		echo "ERROR: Device is not responding to ping."; \
-	# 		exit 1 \
-	# 	)
+.PHONY: active-app
+active-app: check-roku-dev-target
+	@curl --connect-timeout 2 --max-time 4 --silent --show-error \
+		http://$(ROKU_DEV_TARGET):8060/query/active-app
 
-	# second check ECP, to verify we are talking to a Roku
-	rm -f $(DEV_SERVER_TMP_FILE)
-	curl --connect-timeout 2 --silent --output $(DEV_SERVER_TMP_FILE) \
-		http://$(ROKU_DEV_TARGET):8060 || \
-		( \
-			echo "ERROR: Device is not responding to ECP...is it a Roku?"; \
-			exit 1 \
-		)
+.PHONY: device-info
+device-info: check-roku-dev-target
+	@curl --connect-timeout 2 --max-time 4 --silent --show-error \
+		http://$(ROKU_DEV_TARGET):8060/query/device-info
 
-	# echo the device friendly name to let us know what we are talking to
-	ROKU_DEV_NAME=`$(GET_FRIENDLY_NAME_FROM_DD)`; \
-	echo "Device reports as \"$$ROKU_DEV_NAME\"."
-
-	# third check dev web server.
-	# Note, it should return 401 Unauthorized since we aren't passing the password.
-	rm -f $(DEV_SERVER_TMP_FILE)
-	HTTP_STATUS=`curl --connect-timeout 2 --silent --output $(DEV_SERVER_TMP_FILE) \
-		http://$(ROKU_DEV_TARGET)` || \
-		( \
-			echo "ERROR: Device server is not responding...is the developer installer enabled?"; \
-			exit 1 \
-		)
-
-	echo "Dev server is ready."
-endef
-
-# -------------------------------------------------------------------------
-# CHECK_DEVICE_HTTP_STATUS is used to that the last curl command
-# to the dev web server returned HTTP 200 OK.
-# -------------------------------------------------------------------------
-define CHECK_DEVICE_HTTP_STATUS
-	if [ "$$HTTP_STATUS" != "200" ]; then \
-		echo "ERROR: Device returned HTTP $$HTTP_STATUS"; \
-		exit 1; \
-	fi
-endef
-
-# -------------------------------------------------------------------------
-# GET_PLUGIN_PAGE_RESULT_STATUS is used to extract the status message
-# (e.g. Success/Failed) from the dev server plugin_* web page response.
-# (Note that the plugin_install web page has two fields, whereas the
-# plugin_package web page just has one).
-# -------------------------------------------------------------------------
-define GET_PLUGIN_PAGE_RESULT_STATUS
-	cat $(DEV_SERVER_TMP_FILE) | \
-		grep -o "<font color=\"red\">.*" | \
-		sed "s|<font color=\"red\">||" | \
-		sed "s|</font>||"
-endef
-
-# -------------------------------------------------------------------------
-# GET_PLUGIN_PAGE_PACKAGE_LINK is used to extract the installed package
-# URL from the dev server plugin_package web page response.
-# -------------------------------------------------------------------------
-define GET_PLUGIN_PAGE_PACKAGE_LINK =
-	cat $(DEV_SERVER_TMP_FILE) | \
-		grep -o "<a href=\"pkgs//[^\"]*\"" | \
-		sed "s|<a href=\"pkgs//||" | \
-		sed "s|\"||"
-endef
-
-# -------------------------------------------------------------------------
-# install: install the app as the dev channel on the Roku target device.
-# -------------------------------------------------------------------------
 .PHONY: install
-install: $(APPNAME) check
-	@$(CHECK_ROKU_DEV_TARGET)
+install: verify check-roku-dev-target
+	@echo "Installing $(APP_NAME)..."
+	@mkdir -p "$(TMP_DIR)"
+	@HTTP_STATUS=""; \
+		for attempt in 1 2; do \
+			HTTP_STATUS=$$(curl --user "$(ROKU_DEV_USERPASS)" --digest --silent --show-error \
+				-F "mysubmit=Install" -F "archive=@$(APP_ZIP_FILE)" \
+				--output "$(ROKU_RESPONSE_FILE)" \
+				--write-out "%{http_code}" \
+				http://$(ROKU_DEV_TARGET)/plugin_install); \
+			if [ "$$HTTP_STATUS" = "200" ]; then \
+				break; \
+			fi; \
+			if [ "$$attempt" = "1" ]; then \
+				echo "Install attempt returned HTTP $$HTTP_STATUS; retrying..."; \
+				sleep 2; \
+			fi; \
+		done; \
+		if [ "$$HTTP_STATUS" != "200" ]; then \
+			echo "ERROR: Device returned HTTP $$HTTP_STATUS"; \
+			exit 1; \
+		fi
+	@MSG=$$(sed -n 's:.*<font color="red">\(.*\)</font>.*:\1:p' "$(ROKU_RESPONSE_FILE)"); \
+		echo "Result: $$MSG"
 
-	@echo "Installing $(APPNAME)..."
-	@rm -f $(DEV_SERVER_TMP_FILE)
-	@HTTP_STATUS=`curl --user $(USERPASS) --digest --silent --show-error \
-		-F "mysubmit=Install" -F "archive=@$(APP_ZIP_FILE)" \
-		--output $(DEV_SERVER_TMP_FILE) \
-		--write-out "%{http_code}" \
-		http://$(ROKU_DEV_TARGET)/plugin_install`; \
-	$(CHECK_DEVICE_HTTP_STATUS)
-
-	@MSG=`$(GET_PLUGIN_PAGE_RESULT_STATUS)`; \
-	echo "Result: $$MSG"
-
-# -------------------------------------------------------------------------
-# remove: uninstall the dev channel from the Roku target device.
-# -------------------------------------------------------------------------
 .PHONY: remove
-remove:
-	@$(CHECK_ROKU_DEV_TARGET)
-
+remove: check-roku-dev-target
 	@echo "Removing dev app..."
-	@rm -f $(DEV_SERVER_TMP_FILE)
-	@HTTP_STATUS=`curl --user $(USERPASS) --digest --silent --show-error \
+	@mkdir -p "$(TMP_DIR)"
+	@HTTP_STATUS=$$(curl --user "$(ROKU_DEV_USERPASS)" --digest --silent --show-error \
 		-F "mysubmit=Delete" -F "archive=" \
-		--output $(DEV_SERVER_TMP_FILE) \
+		--output "$(ROKU_RESPONSE_FILE)" \
 		--write-out "%{http_code}" \
-		http://$(ROKU_DEV_TARGET)/plugin_install`; \
-	$(CHECK_DEVICE_HTTP_STATUS)
+		http://$(ROKU_DEV_TARGET)/plugin_install); \
+		if [ "$$HTTP_STATUS" != "200" ]; then \
+			echo "ERROR: Device returned HTTP $$HTTP_STATUS"; \
+			exit 1; \
+		fi
+	@MSG=$$(sed -n 's:.*<font color="red">\(.*\)</font>.*:\1:p' "$(ROKU_RESPONSE_FILE)"); \
+		echo "Result: $$MSG"
 
-	@MSG=`$(GET_PLUGIN_PAGE_RESULT_STATUS)`; \
-	echo "Result: $$MSG"
-
-# -------------------------------------------------------------------------
-# check-roku-dev-target: check the status of the Roku target device.
-# -------------------------------------------------------------------------
-.PHONY: check-roku-dev-target
-check-roku-dev-target:
-	@$(CHECK_ROKU_DEV_TARGET)
-
-# -------------------------------------------------------------------------
-# run: the install target is 'smart' and doesn't do anything if the package
-# didn't change.
-# But usually I want to run it even if it didn't change, so force a fresh
-# install by doing a remove first.
-# Some day we should look at doing the force run via a plugin_install flag,
-# but for now just brute force it.
-# -------------------------------------------------------------------------
 .PHONY: run
 run: remove install
 
-# -------------------------------------------------------------------------
-# pkg: use to create a pkg file from the application sources.
-#
-# Usage:
-# The application name should be specified via $APPNAME.
-# The application version should be specified via $VERSION.
-# The developer's signing password (from genkey) should be passed via
-# $APP_KEY_PASS, or via stdin, otherwise the script will prompt for it.
-# -------------------------------------------------------------------------
-.PHONY: pkg
-pkg: install
-	@echo "*** Creating Package ***"
+.PHONY: launch
+launch: check-roku-dev-target
+	@echo "Launching dev app on $(ROKU_DEV_TARGET)..."
+	@curl --connect-timeout 2 --max-time 10 --silent --show-error \
+		--request POST \
+		http://$(ROKU_DEV_TARGET):8060/launch/dev \
+		>/dev/null
+	@ACTIVE_APP=""; \
+		for _ in 1 2 3 4 5 6 7 8 9 10; do \
+			ACTIVE_APP=$$(curl --connect-timeout 2 --max-time 4 --silent --show-error \
+				http://$(ROKU_DEV_TARGET):8060/query/active-app); \
+			if echo "$$ACTIVE_APP" | grep '<app id="dev"' >/dev/null; then \
+				echo "$$ACTIVE_APP"; \
+				exit 0; \
+			fi; \
+			sleep 1; \
+		done; \
+		echo "$$ACTIVE_APP"; \
+		echo "ERROR: Dev app did not become active."; \
+		exit 1
 
-	@echo "  >> creating destination directory $(PKGREL)"
-	@if [ ! -d $(PKGREL) ]; then \
-		mkdir -p $(PKGREL); \
-	fi
+.PHONY: console
+console: check-roku-dev-target
+	@echo "Attaching to BrightScript console at $(ROKU_DEV_TARGET):$(ROKU_DEV_CONSOLE_PORT). Press Ctrl-C to detach."
+	@nc $(ROKU_DEV_TARGET) $(ROKU_DEV_CONSOLE_PORT)
 
-	@echo "  >> setting directory permissions for $(PKGREL)"
-	@if [ ! -w $(PKGREL) ]; then \
-		chmod 755 $(PKGREL); \
-	fi
+.PHONY: live-test
+live-test: check-roku-dev-target active-app device-info
 
-	@$(CHECK_ROKU_DEV_TARGET)
+.PHONY: live-test-launch
+live-test-launch: launch
 
-	@echo "Packaging $(APP_NAME)/$(APP_VERSION) to $(APP_PKG_FILE)"
-
-	@if [ -z "$(APP_KEY_PASS)" ]; then \
-		read -r -p "Password: " REPLY; \
-		echo "$$REPLY" > $(APP_KEY_PASS_TMP); \
-	else \
-		echo "$(APP_KEY_PASS)" > $(APP_KEY_PASS_TMP); \
-	fi
-
-	@rm -f $(DEV_SERVER_TMP_FILE)
-	@PASSWD=`cat $(APP_KEY_PASS_TMP)`; \
-	PKG_TIME=`expr \`date +%s\` \* 1000`; \
-	HTTP_STATUS=`curl --user $(USERPASS) --digest --silent --show-error \
-		-F "mysubmit=Package" -F "app_name=$(APP_NAME)/$(APP_VERSION)" \
-		-F "passwd=$$PASSWD" -F "pkg_time=$$PKG_TIME" \
-		--output $(DEV_SERVER_TMP_FILE) \
-		--write-out "%{http_code}" \
-		http://$(ROKU_DEV_TARGET)/plugin_package`; \
-	$(CHECK_DEVICE_HTTP_STATUS)
-
-	@MSG=`$(GET_PLUGIN_PAGE_RESULT_STATUS)`; \
-	case "$$MSG" in \
-		*Success*) \
-			;; \
-		*)	echo "Result: $$MSG"; \
-			exit 1 \
-			;; \
-	esac
-
-	@PKG_LINK=`$(GET_PLUGIN_PAGE_PACKAGE_LINK)`; \
-	HTTP_STATUS=`curl --user $(USERPASS) --digest --silent --show-error \
-		--output $(APP_PKG_FILE) \
-		--write-out "%{http_code}" \
-		http://$(ROKU_DEV_TARGET)/pkgs/$$PKG_LINK`; \
-	$(CHECK_DEVICE_HTTP_STATUS)
-
-	@echo "*** Package $(APPNAME) complete ***"
-
-# -------------------------------------------------------------------------
-# app-pkg: use to create a pkg file from the application sources.
-# Similar to the pkg target, but does not require a player to do the signing.
-# Instead it requires the developer key file and signing password to be
-# specified, which are then passed to the app-package desktop tool to create
-# the package file.
-#
-# Usage:
-# The application name should be specified via $APPNAME.
-# The application version should be specified via $VERSION.
-# The developer's key file (.pkg file) should be specified via $APP_KEY_FILE.
-# The developer's signing password (from genkey) should be passed via
-# $APP_KEY_PASS, or via stdin, otherwise the script will prompt for it.
-# -------------------------------------------------------------------------
-.PHONY: app-pkg
-app-pkg: $(APPNAME) check
-	@echo "*** Creating package ***"
-
-	@echo "  >> creating destination directory $(PKGREL)"
-	@mkdir -p $(PKGREL) && chmod 755 $(PKGREL)
-
-	@if [ -z "$(APP_KEY_FILE)" ]; then \
-		echo "ERROR: APP_KEY_FILE not defined"; \
-		exit 1; \
-	fi
-	@if [ ! -f "$(APP_KEY_FILE)" ]; then \
-		echo "ERROR: key file not found: $(APP_KEY_FILE)"; \
-		exit 1; \
-	fi
-
-	@if [ -z "$(APP_KEY_PASS)" ]; then \
-		read -r -p "Password: " REPLY; \
-		echo "$$REPLY" > $(APP_KEY_PASS_TMP); \
-	else \
-		echo "$(APP_KEY_PASS)" > $(APP_KEY_PASS_TMP); \
-	fi
-
-	@echo "Packaging $(APP_NAME)/$(APP_VERSION) to $(APP_PKG_FILE)"
-
-	@if [ -z "$(APP_VERSION)" ]; then \
-		echo "WARNING: VERSION is not set."; \
-	fi
-
-	@PASSWD=`cat $(APP_KEY_PASS_TMP)`; \
-	$(APP_PACKAGE_TOOL) package $(APP_ZIP_FILE) \
-		-n $(APP_NAME)/$(APP_VERSION) \
-		-k $(APP_KEY_FILE) \
-		-p "$$PASSWD" \
-		-o $(APP_PKG_FILE)
-
-	@rm $(APP_KEY_PASS_TMP)
-
-	@echo "*** Package $(APPNAME) complete ***"
-
-# -------------------------------------------------------------------------
-# teamcity: used to build .zip and .pkg file on TeamCity.
-# See app-pkg target for info on options for specifying the signing password.
-# -------------------------------------------------------------------------
-.PHONY: teamcity
-teamcity: app-pkg
-ifeq ($(IS_TEAMCITY_BUILD),true)
-	@echo "Adding TeamCity artifacts..."
-
-	sudo rm -f /tmp/artifacts
-	sudo mkdir -p /tmp/artifacts
-
-	cp $(APP_ZIP_FILE) /tmp/artifacts/$(APP_NAME)-$(APP_VERSION).zip
-	@echo "##teamcity[publishArtifacts '/tmp/artifacts/$(APP_NAME)-$(APP_VERSION).zip']"
-
-	cp $(APP_PKG_FILE) /tmp/artifacts/$(APP_NAME)-$(APP_VERSION).pkg
-	@echo "##teamcity[publishArtifacts '/tmp/artifacts/$(APP_NAME)-$(APP_VERSION).pkg']"
-
-	@echo "TeamCity artifacts complete."
-else
-	@echo "Not running on TeamCity, skipping artifacts."
-endif
-
-##########################################################################
-
-# -------------------------------------------------------------------------
-# CHECK_NATIVE_TARGET is used to check if the Roku simulator is
-# configured.
-# -------------------------------------------------------------------------
-define CHECK_NATIVE_TARGET
-	if [ -z "$(ROKU_NATIVE_DEV)" ]; then \
-		echo "ERROR: ROKU_NATIVE_DEV not defined"; \
-		exit 1; \
-	i
-	if [ ! -d "$(ROKU_NATIVE_DEV)" ]; then \
-		echo "ERROR: native dev dir not found: $(ROKU_NATIVE_DEV)"; \
-		exit 1; \
-	fi
-	if [ ! -d "$(NATIVE_DIST_DIR)" ]; then \
-		echo "ERROR: native build dir not found: $(NATIVE_DIST_DIR)"; \
-		exit 1; \
-	fi
-endef
-
-# -------------------------------------------------------------------------
-# install-native: install the app as the dev channel on the Roku simulator.
-# -------------------------------------------------------------------------
-.PHONY: install-native
-install-native: $(APPNAME) check
-	@$(CHECK_NATIVE_TARGET)
-	@echo "Installing $(APPNAME) to native."
-	@if [ ! -d "$(NATIVE_DEV_REL)" ]; then \
-		mkdir "$(NATIVE_DEV_REL)"; \
-	fi
-	@echo "Source is $(APP_ZIP_FILE)"
-	@echo "Target is $(NATIVE_DEV_PKG)"
-	@cp $(APP_ZIP_FILE) $(NATIVE_DEV_PKG)
-	@$(NATIVE_TICKLER)
-
-# -------------------------------------------------------------------------
-# remove-native: uninstall the dev channel from the Roku simulator.
-# -------------------------------------------------------------------------
-.PHONY: remove-native
-remove-native:
-	@$(CHECK_NATIVE_TARGET)
-	@echo "Removing $(APPNAME) from native."
-	@rm $(NATIVE_DEV_PKG)
-	@$(NATIVE_TICKLER)
-
-##########################################################################
-
-# -------------------------------------------------------------------------
-# art-jpg-opt: compress any jpg files in the source tree.
-# Used by the art-opt target.
-# -------------------------------------------------------------------------
-APPS_JPG_ART=`\find . -name "*.jpg"`
-
-.PHONY: art-jpg-opt
-art-jpg-opt:
-	p4 edit $(APPS_JPG_ART)
-	for i in $(APPS_JPG_ART); \
-	do \
-		TMPJ=`mktemp` || return 1; \
-		echo "optimizing $$i"; \
-		(jpegtran -copy none -optimize -outfile $$TMPJ $$i && mv -f $$TMPJ $$i &); \
-	done
-	wait
-	p4 revert -a $(APPS_JPG_ART)
-
-# -------------------------------------------------------------------------
-# art-png-opt: compress any png files in the source tree.
-# Used by the art-opt target.
-# -------------------------------------------------------------------------
-APPS_PNG_ART=`\find . -name "*.png"`
-
-.PHONY: art-png-opt
-art-png-opt:
-	p4 edit $(APPS_PNG_ART)
-	for i in $(APPS_PNG_ART); \
-	do \
-		(optipng -o7 $$i &); \
-	done
-	wait
-	p4 revert -a $(APPS_PNG_ART)
-
-# -------------------------------------------------------------------------
-# art-opt: compress any png and jpg files in the source tree using
-# lossless compression options.
-# This assumes a Perforce client/workspace is configured.
-# Modified files are opened for edit in the default changelist.
-# -------------------------------------------------------------------------
-.PHONY: art-opt
-art-opt: art-png-opt art-jpg-opt
-
-##########################################################################
-
-# -------------------------------------------------------------------------
-# tr: this target is used to update translation files for an application
-# MAKE_TR_OPTIONS may be set to [-t] [-d] etc. in the external environment,
-# if needed.
-# -------------------------------------------------------------------------
-.PHONY: tr
-tr:
-	p4 opened -c default
-	p4 edit locale/.../translations.xml
-	$(MAKE_TR_TOOL) $(MAKE_TR_OPTIONS)
-	rm locale/en_US/translations.xml
-	p4 revert -a locale/.../translations.xml
-	p4 opened -c default
-
-##########################################################################
+.PHONY: live-test-install
+live-test-install: run launch

--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,12 @@ check-roku-static:
 	@echo "*** Running Roku static checks ***"
 	pnpm exec bslint --project bsconfig.json
 
+.PHONY: check-roku-live
+check-roku-live:
+	pnpm run check:live
+
 .PHONY: verify
-verify: clean check-roku-static build
+verify: clean check-roku-live check-roku-static build
 	@test -f "$(APP_ZIP_FILE)"
 
 .PHONY: smoke
@@ -167,6 +171,26 @@ console: check-roku-dev-target
 
 .PHONY: live-test
 live-test: check-roku-dev-target active-app device-info
+
+.PHONY: live-test-control
+live-test-control:
+	ROKU_DEV_TARGET=$(ROKU_DEV_TARGET) pnpm roku:live control-smoke
+
+.PHONY: live-test-press
+live-test-press:
+	@if [ -z "$(KEYS)" ]; then \
+		echo "ERROR: KEYS is not set. Example: make live-test-press KEYS=\"Back Info\""; \
+		exit 1; \
+	fi
+	ROKU_DEV_TARGET=$(ROKU_DEV_TARGET) pnpm roku:live press $(KEYS)
+
+.PHONY: live-test-deeplink
+live-test-deeplink:
+	@if [ -z "$(CONTENT_ID)" ]; then \
+		echo "ERROR: CONTENT_ID is not set. Example: make live-test-deeplink CONTENT_ID=1587417579"; \
+		exit 1; \
+	fi
+	ROKU_DEV_TARGET=$(ROKU_DEV_TARGET) pnpm roku:live launch-deeplink $(CONTENT_ID) $(or $(MEDIA_TYPE),movie)
 
 .PHONY: live-test-launch
 live-test-launch: launch

--- a/README.md
+++ b/README.md
@@ -36,8 +36,19 @@ After installation, sign in with your put.io account to:
 ## Docs
 
 - [Sideloading guide](./docs/SIDELOADING.md) for device setup and ZIP installation
+- [Live Test](./live-test/README.md) for hardware-backed debugging and agent readiness checks
 - [Release workflow](./docs/RELEASE.md) for [GitHub Releases](https://github.com/putdotio/putio-roku/releases) and [roku.put.io](https://roku.put.io/v2.zip) publishing
 - [Security](./SECURITY.md) for private vulnerability reporting
+
+## Development
+
+The app is BrightScript/SceneGraph, with `brighterscript`, `bslint`, and
+`roku-deploy` installed through pnpm for local and CI validation.
+
+```bash
+pnpm install --frozen-lockfile
+make verify
+```
 
 ## Contributing
 

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -1,0 +1,19 @@
+{
+  "files": [
+    "manifest",
+    "source/**/*.*",
+    "components/**/*.*",
+    "images/**/*.*"
+  ],
+  "plugins": ["@rokucommunity/bslint"],
+  "lintConfig": "bslint.json",
+  "diagnosticFilters": [
+    "node_modules/**/*",
+    "**/roku_modules/**/*"
+  ],
+  "sourceMap": true,
+  "autoImportComponentScript": false,
+  "stagingDir": "build/staging",
+  "outFile": "build/putio-roku.zip",
+  "retainStagingDir": true
+}

--- a/bslint.json
+++ b/bslint.json
@@ -1,0 +1,18 @@
+{
+  "rules": {
+    "inline-if-style": "off",
+    "block-if-style": "off",
+    "condition-style": "off",
+    "named-function-style": "off",
+    "anon-function-style": "off",
+    "aa-comma-style": "off",
+    "eol-last": "off",
+    "assign-all-paths": "off",
+    "unsafe-path-loop": "off",
+    "unsafe-iterators": "off",
+    "unreachable-code": "off",
+    "case-sensitivity": "warn",
+    "consistent-return": "warn",
+    "unused-variable": "warn"
+  }
+}

--- a/components/App.brs
+++ b/components/App.brs
@@ -1,6 +1,7 @@
 function init()
     m.storage = CreateObject("roRegistrySection", "userConfig")
     m.pendingDeepLink = invalid
+    m.replaceRoute = false
     m.top.observeField("deepLink", "onDeepLink")
     configureRouter()
     queueDeepLink(m.top.deepLink)
@@ -23,8 +24,12 @@ sub onNavigateToRoute(obj)
     currentRouteScreen.unobserveField("showDialog")
     currentRouteScreen.visible = false
 
-    m.activeRoute.params = currentRouteScreen.params
-    m.routeHistory.push(m.activeRoute)
+    if m.replaceRoute
+        m.replaceRoute = false
+    else
+        m.activeRoute.params = currentRouteScreen.params
+        m.routeHistory.push(m.activeRoute)
+    end if
     m.activeRoute = nextRoute
 
     nextRouteScreen = m.top.findNode(nextRoute.id)
@@ -188,7 +193,13 @@ sub routePendingDeepLink()
         return
     end if
 
-    m.routeHistory = []
+    m.routeHistory = [
+        {
+            id: "homeScreen",
+            params: {}
+        }
+    ]
+    m.replaceRoute = true
     m.global.route = {
         id: "videoScreen",
         params: {

--- a/components/App.brs
+++ b/components/App.brs
@@ -1,43 +1,21 @@
 function init()
-  m.storage = CreateObject("roRegistrySection", "userConfig")
-  configureRouter()
-  checkToken()
+    m.storage = CreateObject("roRegistrySection", "userConfig")
+    m.pendingDeepLink = invalid
+    m.top.observeField("deepLink", "onDeepLink")
+    configureRouter()
+    queueDeepLink(m.top.deepLink)
+    checkToken()
 end function
 
 sub configureRouter()
-  m.routeHistory = []
-  m.activeRoute = m.global.route
-  m.global.observeField("route", "onNavigateToRoute")
+    m.routeHistory = []
+    m.activeRoute = m.global.route
+    m.global.observeField("route", "onNavigateToRoute")
 end sub
 
 sub onNavigateToRoute(obj)
-  nextRoute = obj.getData()
+    nextRoute = obj.getData()
 
-  currentRouteScreen = m.top.findNode(m.activeRoute.id)
-  currentRouteScreen.unobserveField("navigate")
-  currentRouteScreen.unobserveField("navigateBack")
-  currentRouteScreen.unobserveField("showExitAppDialog")
-  currentRouteScreen.unobserveField("showDialog")
-  currentRouteScreen.visible = false
-
-  m.activeRoute.params = currentRouteScreen.params
-  m.routeHistory.push(m.activeRoute)
-  m.activeRoute = nextRoute
-
-  nextRouteScreen = m.top.findNode(nextRoute.id)
-  nextRouteScreen.params = nextRoute.params
-  nextRouteScreen.observeField("navigate", "onNavigateToRoute")
-  nextRouteScreen.observeField("navigateBack", "onNavigateBack")
-  nextRouteScreen.observeField("showExitAppDialog", "onShowExitAppDialog")
-  nextRouteScreen.observeField("showDialog", "onShowDialog")
-  nextRouteScreen.visible = true
-  nextRouteScreen.setFocus(true)
-end sub
-
-sub onNavigateBack()
-  prevRoute = m.routeHistory.pop()
-
-  if prevRoute <> invalid
     currentRouteScreen = m.top.findNode(m.activeRoute.id)
     currentRouteScreen.unobserveField("navigate")
     currentRouteScreen.unobserveField("navigateBack")
@@ -45,90 +23,199 @@ sub onNavigateBack()
     currentRouteScreen.unobserveField("showDialog")
     currentRouteScreen.visible = false
 
-    m.activeRoute = prevRoute
+    m.activeRoute.params = currentRouteScreen.params
+    m.routeHistory.push(m.activeRoute)
+    m.activeRoute = nextRoute
 
-    prevRouteScreenScreen = m.top.findNode(prevRoute.id)
-    prevRouteScreenScreen.params = prevRoute.params
-    prevRouteScreenScreen.observeField("navigate", "onNavigateToRoute")
-    prevRouteScreenScreen.observeField("navigateBack", "onNavigateBack")
-    prevRouteScreenScreen.observeField("showExitAppDialog", "onShowExitAppDialog")
-    prevRouteScreenScreen.observeField("showDialog", "onShowDialog")
-    prevRouteScreenScreen.visible = true
-    prevRouteScreenScreen.setFocus(true)
-  end if
+    nextRouteScreen = m.top.findNode(nextRoute.id)
+    nextRouteScreen.params = nextRoute.params
+    nextRouteScreen.observeField("navigate", "onNavigateToRoute")
+    nextRouteScreen.observeField("navigateBack", "onNavigateBack")
+    nextRouteScreen.observeField("showExitAppDialog", "onShowExitAppDialog")
+    nextRouteScreen.observeField("showDialog", "onShowDialog")
+    nextRouteScreen.visible = true
+    nextRouteScreen.setFocus(true)
+end sub
+
+sub onNavigateBack()
+    prevRoute = m.routeHistory.pop()
+
+    if prevRoute <> invalid
+        currentRouteScreen = m.top.findNode(m.activeRoute.id)
+        currentRouteScreen.unobserveField("navigate")
+        currentRouteScreen.unobserveField("navigateBack")
+        currentRouteScreen.unobserveField("showExitAppDialog")
+        currentRouteScreen.unobserveField("showDialog")
+        currentRouteScreen.visible = false
+
+        m.activeRoute = prevRoute
+
+        prevRouteScreenScreen = m.top.findNode(prevRoute.id)
+        prevRouteScreenScreen.params = prevRoute.params
+        prevRouteScreenScreen.observeField("navigate", "onNavigateToRoute")
+        prevRouteScreenScreen.observeField("navigateBack", "onNavigateBack")
+        prevRouteScreenScreen.observeField("showExitAppDialog", "onShowExitAppDialog")
+        prevRouteScreenScreen.observeField("showDialog", "onShowDialog")
+        prevRouteScreenScreen.visible = true
+        prevRouteScreenScreen.setFocus(true)
+    end if
 end sub
 
 sub goToAuthScreen()
-  m.global.route = {
-    id: "authScreen",
-    params: {},
-  }
-  authScreen = m.top.findNode("authScreen")
-  authScreen.observeField("token", "onTokenRetrieved")
+    m.global.route = {
+        id: "authScreen",
+        params: {},
+    }
+    authScreen = m.top.findNode("authScreen")
+    authScreen.observeField("token", "onTokenRetrieved")
 end sub
 
 sub checkToken()
-  if m.storage.Exists("token")
-    m.token = m.storage.Read("token")
-  else
-    m.token = ""
-  end if
+    if m.storage.Exists("token")
+        m.token = m.storage.Read("token")
+    else
+        m.token = ""
+    end if
 
-  if (m.token = "") Then
-    goToAuthScreen()
-  else
-    getUserInfo()
-  end if
+    if (m.token = "") then
+        goToAuthScreen()
+    else
+        getUserInfo()
+    end if
 end sub
 
 sub onTokenRetrieved(obj)
-  m.token = obj.getData()
-  m.storage.Write("token", m.token)
-  m.storage.Flush()
-  getUserInfo()
+    m.token = obj.getData()
+    m.storage.Write("token", m.token)
+    m.storage.Flush()
+    getUserInfo()
 end sub
 
 sub getUserInfo()
-  m.httpTask = createObject("roSGNode", "HttpTask")
-  m.httpTask.observeField("response", "onUserInfoResponse")
-  m.httpTask.url = "/account/info?download_token=1"
-  m.httpTask.control = "RUN"
+    m.httpTask = createObject("roSGNode", "HttpTask")
+    m.httpTask.observeField("response", "onUserInfoResponse")
+    m.httpTask.url = "/account/info?download_token=1"
+    m.httpTask.control = "RUN"
 end sub
 
 sub onUserInfoResponse(obj)
-  m.httpTask.unobserveField("response")
-  data = parseJSON(obj.getData())
+    m.httpTask.unobserveField("response")
+    data = parseJSON(obj.getData())
 
-  if data <> invalid and data.info <> invalid
-    m.routeHistory = []
-    m.global.user = data.info
-    m.global.route = {
-      id: "homeScreen",
-      params: {}
+    if data <> invalid and data.info <> invalid
+        m.routeHistory = []
+        m.global.user = data.info
+        if m.pendingDeepLink <> invalid
+            routePendingDeepLink()
+        else
+            m.global.route = {
+                id: "homeScreen",
+                params: {}
+            }
+        end if
+    else
+        goToAuthScreen()
+    end if
+end sub
+
+sub onDeepLink(obj)
+    queueDeepLink(obj.getData())
+
+    if isAuthenticated() and m.pendingDeepLink <> invalid
+        routePendingDeepLink()
+    end if
+end sub
+
+sub queueDeepLink(args)
+    deepLink = normalizeVideoDeepLink(args)
+
+    if deepLink <> invalid
+        m.pendingDeepLink = deepLink
+    end if
+end sub
+
+function normalizeVideoDeepLink(args)
+    if args = invalid
+        return invalid
+    end if
+
+    contentId = readDeepLinkValue(args, "contentID")
+    if contentId = invalid
+        contentId = readDeepLinkValue(args, "contentId")
+    end if
+
+    mediaType = readDeepLinkValue(args, "mediaType")
+    if mediaType = invalid
+        return invalid
+    end if
+
+    normalizedMediaType = LCase(mediaType.toStr())
+    if normalizedMediaType <> "movie" and normalizedMediaType <> "episode" and normalizedMediaType <> "video" and normalizedMediaType <> "shortformvideo"
+        return invalid
+    end if
+
+    if contentId = invalid
+        return invalid
+    end if
+
+    fileId = contentId.toStr().toInt()
+    if fileId <= 0
+        return invalid
+    end if
+
+    return {
+        fileId: fileId,
     }
-  else
-    goToAuthScreen()
-  end if
+end function
+
+function readDeepLinkValue(args, key)
+    if args <> invalid and args.doesExist(key)
+        return args[key]
+    end if
+
+    return invalid
+end function
+
+function isAuthenticated()
+    return m.global.user <> invalid and m.global.user.id <> invalid
+end function
+
+sub routePendingDeepLink()
+    deepLink = m.pendingDeepLink
+    m.pendingDeepLink = invalid
+
+    if deepLink = invalid
+        return
+    end if
+
+    m.routeHistory = []
+    m.global.route = {
+        id: "videoScreen",
+        params: {
+            fileId: deepLink.fileId,
+            fileName: "",
+        },
+    }
 end sub
 
 sub onShowDialog(obj)
-  m.top.dialog = obj.getData()
+    m.top.dialog = obj.getData()
 end sub
 
 sub onShowExitAppDialog(obj)
-  if obj.getData() = true
-    m.dialog = createObject("roSGNode", "Dialog")
-    m.dialog.title = "Exit put.io?"
-    m.dialog.buttons = ["OK", "Cancel"]
-    m.dialog.observeField("buttonSelected", "onExitAppDialogButtonSelected")
-    m.top.dialog = m.dialog
-  end if
+    if obj.getData() = true
+        m.dialog = createObject("roSGNode", "Dialog")
+        m.dialog.title = "Exit put.io?"
+        m.dialog.buttons = ["OK", "Cancel"]
+        m.dialog.observeField("buttonSelected", "onExitAppDialogButtonSelected")
+        m.top.dialog = m.dialog
+    end if
 end sub
 
 sub onExitAppDialogButtonSelected(obj)
-  if obj.getData() = 0
-    m.top.exitApp = true
-  else
-    m.dialog.close = true
-  end if
+    if obj.getData() = 0
+        m.top.exitApp = true
+    else
+        m.dialog.close = true
+    end if
 end sub

--- a/components/App.xml
+++ b/components/App.xml
@@ -5,6 +5,7 @@
 
   <interface>
     <field id="exitApp" type="boolean" value="false" />
+    <field id="deepLink" type="assocarray" alwaysNotify="true" />
   </interface>
 
   <children>

--- a/components/screens/Audio/Audio.brs
+++ b/components/screens/Audio/Audio.brs
@@ -1,241 +1,241 @@
 function init()
-  m.top.observeField("visible", "onVisibleChange")
+    m.top.observeField("visible", "onVisibleChange")
 
-  m.audio = m.top.findNode("audio")
-  m.overhang = m.top.findNode("overhang")
-  m.loading = m.top.findNode("loading")
-  m.audioPlayer = m.top.findNode("audioPlayer")
-  m.rewindButton = m.top.findNode("rewind")
-  m.fastForwardButton = m.top.findNode("fastForward")
-  m.playButton = m.top.findNode("play")
-  m.controls = m.top.findNode("controls")
-  m.progress = m.top.findNode("progress")
-  m.progressBar = m.top.findNode("progressBar")
+    m.audio = m.top.findNode("audio")
+    m.overhang = m.top.findNode("overhang")
+    m.loading = m.top.findNode("loading")
+    m.audioPlayer = m.top.findNode("audioPlayer")
+    m.rewindButton = m.top.findNode("rewind")
+    m.fastForwardButton = m.top.findNode("fastForward")
+    m.playButton = m.top.findNode("play")
+    m.controls = m.top.findNode("controls")
+    m.progress = m.top.findNode("progress")
+    m.progressBar = m.top.findNode("progressBar")
 
-  m.position = m.top.findNode("position")
-  m.duration = m.top.findNode("duration")
+    m.position = m.top.findNode("position")
+    m.duration = m.top.findNode("duration")
 
-  translationWidth = (getParentWidth() - m.playButton.width * 4) / 2
-  translationHeight = (getParentHeight() - m.playButton.height) / 2
-  m.audioPlayer.translation = [translationWidth, translationHeight]
-  m.progress.translation = [(getParentWidth() - m.progressBar.width * 1.34) / 2, translationHeight + 2 * m.playButton.height]
+    translationWidth = (getParentWidth() - m.playButton.width * 4) / 2
+    translationHeight = (getParentHeight() - m.playButton.height) / 2
+    m.audioPlayer.translation = [translationWidth, translationHeight]
+    m.progress.translation = [(getParentWidth() - m.progressBar.width * 1.34) / 2, translationHeight + 2 * m.playButton.height]
 
-  m.focusOrder = [
-    {
-      component: m.playButton,
-      callback: playOrPause,
-    },
-    {
-      component: m.fastForwardButton,
-      callback: fastforward,
-    },
-    {
-      component: m.rewindButton,
-      callback: rewind,
-    },
-  ]
-  m.focusIndex = 0
+    m.focusOrder = [
+        {
+            component: m.playButton,
+            callback: playOrPause,
+        },
+        {
+            component: m.fastForwardButton,
+            callback: fastforward,
+        },
+        {
+            component: m.rewindButton,
+            callback: rewind,
+        },
+    ]
+    m.focusIndex = 0
 end function
 
 sub onVisibleChange()
-  if m.top.visible
-    m.overhang.title = m.top.params.fileName
-    m.audio.observeField("state", "onAudioStateChange")
-    m.audio.observeField("position", "onPositionChange")
-    m.audio.observeField("duration", "onDurationChange")
+    if m.top.visible
+        m.overhang.title = m.top.params.fileName
+        m.audio.observeField("state", "onAudioStateChange")
+        m.audio.observeField("position", "onPositionChange")
+        m.audio.observeField("duration", "onDurationChange")
 
-    setupPlayer()
+        setupPlayer()
 
-    m.playButton.setFocus(true)
-    onAudioStateChange() ' to update play button's icon
-    m.focusIndex = 0
+        m.playButton.setFocus(true)
+        onAudioStateChange() ' to update play button's icon
+        m.focusIndex = 0
 
-    m.loading.visible = "true"
-  else
-    m.audio.control = "stop"
-    m.audio.unobserveField("state")
-    m.audio.unobserveField("position")
-    m.audio.unobserveField("duration")
+        m.loading.visible = "true"
+    else
+        m.audio.control = "stop"
+        m.audio.unobserveField("state")
+        m.audio.unobserveField("position")
+        m.audio.unobserveField("duration")
 
-    m.focusOrder[m.focusIndex].component.uri = m.focusOrder[m.focusIndex].component.uri.replace("-focused", "")
-  end if
+        m.focusOrder[m.focusIndex].component.uri = m.focusOrder[m.focusIndex].component.uri.replace("-focused", "")
+    end if
 end sub
 
 sub setupPlayer()
-  audioContent = createObject("RoSGNode", "ContentNode")
+    audioContent = createObject("RoSGNode", "ContentNode")
 
-  audioContent.url = (m.global.apiURL + "/files/" + m.top.params.fileId.toStr() + "/stream.mp3?oauth_token=" + m.global.user.download_token.toStr() + "")
+    audioContent.url = (m.global.apiURL + "/files/" + m.top.params.fileId.toStr() + "/stream.mp3?oauth_token=" + m.global.user.download_token.toStr() + "")
 
-  audioContent.title = m.top.params.fileName
+    audioContent.title = m.top.params.fileName
 
-  m.audio.content = audioContent
-  m.audio.control = "play"
+    m.audio.content = audioContent
+    m.audio.control = "play"
 
-  m.audio.seek = 0
+    m.audio.seek = 0
 end sub
 
 sub onAudioStateChange()
-  m.loading.visible = m.audio.state = "buffering"
-  if m.audio.state = "playing"
-    if m.playButton.hasFocus()
-      m.playButton.uri = "pkg:/images/icons/pause-4-focused.png"
-    else
-      m.playButton.uri = "pkg:/images/icons/pause-4.png"
+    m.loading.visible = m.audio.state = "buffering"
+    if m.audio.state = "playing"
+        if m.playButton.hasFocus()
+            m.playButton.uri = "pkg:/images/icons/pause-4-focused.png"
+        else
+            m.playButton.uri = "pkg:/images/icons/pause-4.png"
+        end if
+    else if m.audio.state = "paused" or m.audio.state = "stopped" or m.audio.state = "finished"
+        if m.playButton.hasFocus()
+            m.playButton.uri = "pkg:/images/icons/play-4-focused.png"
+        else
+            m.playButton.uri = "pkg:/images/icons/play-4.png"
+        end if
+    else if m.audio.state = "error"
+        showAudioErrorDialog()
     end if
-  else if m.audio.state = "paused" or m.audio.state = "stopped" or m.audio.state = "finished"
-    if m.playButton.hasFocus()
-      m.playButton.uri = "pkg:/images/icons/play-4-focused.png"
-    else
-      m.playButton.uri = "pkg:/images/icons/play-4.png"
-    end if
-  else if m.audio.state = "error"
-    showAudioErrorDialog()
-  end if
 end sub
 
 sub showAudioErrorDialog()
-  m.audioLoadErrorDialog = createObject("roSGNode", "ErrorDialog")
-  m.audioLoadErrorDialog.title = "Oops :("
-  m.audioLoadErrorDialog.message = "Audio file can not be loaded!"
-  m.audioLoadErrorDialog.observeField("wasClosed", "onAudioLoadErrorDialogClosed")
-  m.top.showDialog = m.audioLoadErrorDialog
+    m.audioLoadErrorDialog = createObject("roSGNode", "ErrorDialog")
+    m.audioLoadErrorDialog.title = "Oops :("
+    m.audioLoadErrorDialog.message = "Audio file can not be loaded!"
+    m.audioLoadErrorDialog.observeField("wasClosed", "onAudioLoadErrorDialogClosed")
+    m.top.showDialog = m.audioLoadErrorDialog
 end sub
 
 sub onAudioLoadErrorDialogClosed()
-  m.top.navigateBack = "true"
+    m.top.navigateBack = "true"
 end sub
 
 sub onPositionChange()
-  if m.audio.position <> invalid
-    m.position.text = getDurationString(m.audio.position)
-    m.progressBar.percentage = (m.audio.position / m.audio.duration) * 100
-  else
-    m.position.text = "..:.."
-  end if
+    if m.audio.position <> invalid
+        m.position.text = getDurationString(m.audio.position)
+        m.progressBar.percentage = (m.audio.position / m.audio.duration) * 100
+    else
+        m.position.text = "..:.."
+    end if
 end sub
 
 sub onDurationChange()
-  if m.audio.duration <> invalid
-    m.duration.text = getDurationString(m.audio.duration)
-  else
-    m.duration.text = "..:.."
-  end if
+    if m.audio.duration <> invalid
+        m.duration.text = getDurationString(m.audio.duration)
+    else
+        m.duration.text = "..:.."
+    end if
 end sub
 
 sub playOrPause()
-  if m.audio.state = "playing"
-    m.audio.control = "pause"
-  else
-    m.audio.control = "resume"
-  end if
+    if m.audio.state = "playing"
+        m.audio.control = "pause"
+    else
+        m.audio.control = "resume"
+    end if
 end sub
 
 sub rewind()
-  m.audio.seek = m.audio.position - 15
+    m.audio.seek = m.audio.position - 15
 end sub
 
 sub fastforward()
-  if m.audio.position + 15 < m.audio.duration
-    m.audio.seek = m.audio.position + 15
-  end if
+    if m.audio.position + 15 < m.audio.duration
+        m.audio.seek = m.audio.position + 15
+    end if
 end sub
 
 sub setNextFocusIndex()
-  oldFocusIndex = m.focusIndex
-  if m.focusIndex + 1 = m.focusOrder.count()
-    newFocusIndex = 0
-  else
-    newFocusIndex = m.focusIndex + 1
-  end if
+    oldFocusIndex = m.focusIndex
+    if m.focusIndex + 1 = m.focusOrder.count()
+        newFocusIndex = 0
+    else
+        newFocusIndex = m.focusIndex + 1
+    end if
 
-  updateFocusIcons(oldFocusIndex, newFocusIndex)
-  m.focusIndex = newFocusIndex
+    updateFocusIcons(oldFocusIndex, newFocusIndex)
+    m.focusIndex = newFocusIndex
 end sub
 
 sub setPrevFocusIndex()
-  oldFocusIndex = m.focusIndex
-  if m.focusIndex - 1 = -1
-    newFocusIndex = m.focusOrder.count() - 1
-  else
-    newFocusIndex = m.focusIndex - 1
-  end if
+    oldFocusIndex = m.focusIndex
+    if m.focusIndex - 1 = -1
+        newFocusIndex = m.focusOrder.count() - 1
+    else
+        newFocusIndex = m.focusIndex - 1
+    end if
 
-  updateFocusIcons(oldFocusIndex, newFocusIndex)
-  m.focusIndex = newFocusIndex
+    updateFocusIcons(oldFocusIndex, newFocusIndex)
+    m.focusIndex = newFocusIndex
 end sub
 
 sub updateFocusIcons(oldFocusIndex, newFocusIndex)
-  m.focusOrder[newFocusIndex].component.setFocus(true)
-  m.focusOrder[oldFocusIndex].component.uri = m.focusOrder[oldFocusIndex].component.uri.replace("-focused", "")
-  m.focusOrder[newFocusIndex].component.uri = m.focusOrder[newFocusIndex].component.uri.replace(".png", "-focused.png")
+    m.focusOrder[newFocusIndex].component.setFocus(true)
+    m.focusOrder[oldFocusIndex].component.uri = m.focusOrder[oldFocusIndex].component.uri.replace("-focused", "")
+    m.focusOrder[newFocusIndex].component.uri = m.focusOrder[newFocusIndex].component.uri.replace(".png", "-focused.png")
 end sub
 
 function onKeyEvent(key, press)
-  if m.top.visible and press
-    if key = "back"
-      m.top.navigateBack = "true"
-    else if key = "play"
-      playOrPause()
-    else if key = "rewind"
-      rewind()
-    else if key = "fastforward"
-      fastforward()
-    else if key = "replay"
-      m.audio.seek = 0
-    else if key = "OK"
-      callback = m.focusOrder[m.focusIndex].callback
-      callback()
-    else if key = "right"
-      setNextFocusIndex()
-    else if key = "left"
-      setPrevFocusIndex()
-    else
-      return false
+    if m.top.visible and press
+        if key = "back"
+            m.top.navigateBack = "true"
+        else if key = "play"
+            playOrPause()
+        else if key = "rewind"
+            rewind()
+        else if key = "fastforward"
+            fastforward()
+        else if key = "replay"
+            m.audio.seek = 0
+        else if key = "OK"
+            callback = m.focusOrder[m.focusIndex].callback
+            callback()
+        else if key = "right"
+            setNextFocusIndex()
+        else if key = "left"
+            setPrevFocusIndex()
+        else
+            return false
+        end if
+        return true
     end if
-    return true
-  end if
 
-  return false
+    return false
 end function
 
 function getParentWidth() as float
-  if m.top.getParent() <> invalid and m.top.getParent().width <> invalid then
-    return m.top.getParent().width
-  else
-    return 1920
-  end if
+    if m.top.getParent() <> invalid and m.top.getParent().width <> invalid then
+        return m.top.getParent().width
+    else
+        return 1920
+    end if
 end function
 
 
 function getParentHeight() as float
-  if m.top.getParent() <> invalid and m.top.getParent().height <> invalid then
-    return m.top.getParent().height
-  else
-    return 1080
-  end if
+    if m.top.getParent() <> invalid and m.top.getParent().height <> invalid then
+        return m.top.getParent().height
+    else
+        return 1080
+    end if
 end function
 
-sub getDurationString(seconds) as String
-	datetime = CreateObject("roDateTime")
-	datetime.FromSeconds(seconds)
+sub getDurationString(seconds) as string
+    datetime = CreateObject("roDateTime")
+    datetime.FromSeconds(seconds)
 
-	hours = datetime.GetHours().ToStr()
-	minutes = datetime.GetMinutes().ToStr()
-	seconds = datetime.GetSeconds().ToStr()
+    hours = datetime.GetHours().ToStr()
+    minutes = datetime.GetMinutes().ToStr()
+    seconds = datetime.GetSeconds().ToStr()
 
-	If Len(hours) = 1 Then
-		hours = "0" + hours
-	End If
-	If Len(minutes) = 1 Then
-		minutes = "0" + minutes
-	End If
-	If Len(seconds) = 1 Then
-		seconds = "0" + seconds
-	End If
+    if Len(hours) = 1 then
+        hours = "0" + hours
+    end if
+    if Len(minutes) = 1 then
+        minutes = "0" + minutes
+    end if
+    if Len(seconds) = 1 then
+        seconds = "0" + seconds
+    end if
 
-	if hours <> "00"
-		return hours + ":" + minutes + ":" + seconds
-	else
-		return minutes + ":" + seconds
-	end if
+    if hours <> "00"
+        return hours + ":" + minutes + ":" + seconds
+    else
+        return minutes + ":" + seconds
+    end if
 end sub

--- a/components/screens/Auth/Auth.brs
+++ b/components/screens/Auth/Auth.brs
@@ -1,71 +1,71 @@
 function init()
-  m.top.observeField("visible", "onVisibleChange")
+    m.top.observeField("visible", "onVisibleChange")
 
-  m.codeLabel = m.top.findNode("code")
-  m.messageLabel = m.top.findNode("message")
-  m.code = ""
+    m.codeLabel = m.top.findNode("code")
+    m.messageLabel = m.top.findNode("message")
+    m.code = ""
 
-  m.timer = createObject("roSGNode", "Timer")
-  m.timer.duration = 2
-  m.timer.observeField("fire", "onTimerFired")
+    m.timer = createObject("roSGNode", "Timer")
+    m.timer.duration = 2
+    m.timer.observeField("fire", "onTimerFired")
 end function
 
 sub onVisibleChange()
-  if m.top.visible
-    getAuthCode()
-  end if
+    if m.top.visible
+        getAuthCode()
+    end if
 end sub
 
 sub getAuthCode()
-	deviceInfo = createObject("roDeviceInfo")
-  m.code = ""
-  m.getCodeTask = createObject("roSGNode", "HttpTask")
-  m.getCodeTask.observeField("response", "onAuthCodeResponse")
-  m.getCodeTask.url = "/oauth2/oob/code?app_id=" + m.global.appId + "&client_name=" + deviceInfo.getFriendlyName().EncodeUri()
-  m.getCodeTask.control = "RUN"
+    deviceInfo = createObject("roDeviceInfo")
+    m.code = ""
+    m.getCodeTask = createObject("roSGNode", "HttpTask")
+    m.getCodeTask.observeField("response", "onAuthCodeResponse")
+    m.getCodeTask.url = "/oauth2/oob/code?app_id=" + m.global.appId + "&client_name=" + deviceInfo.getFriendlyName().EncodeUri()
+    m.getCodeTask.control = "RUN"
 end sub
 
 sub onAuthCodeResponse(obj)
-  m.getCodeTask.unobserveField("response")
-  data = parseJSON(obj.getData())
+    m.getCodeTask.unobserveField("response")
+    data = parseJSON(obj.getData())
 
-  if data.code <> invalid
-    m.code = data.code
-    m.codeLabel.text = data.code
-    checkCodeMatch()
-  else
-    m.codeLabel.text = "Error!"
-    m.messageLabel.text = "An error occurred while getting the authentication code, please restart the app and try again."
-  end if
+    if data.code <> invalid
+        m.code = data.code
+        m.codeLabel.text = data.code
+        checkCodeMatch()
+    else
+        m.codeLabel.text = "Error!"
+        m.messageLabel.text = "An error occurred while getting the authentication code, please restart the app and try again."
+    end if
 end sub
 
 sub onTimerFired()
-  checkCodeMatch()
+    checkCodeMatch()
 end sub
 
 sub checkCodeMatch()
-  m.checkCodeTask = createObject("roSGNode", "HttpTask")
-  m.checkCodeTask.observeField("response", "onCheckCodeMatchResponse")
-  m.checkCodeTask.url = ("/oauth2/oob/code/" + m.code)
-  m.checkCodeTask.control = "RUN"
+    m.checkCodeTask = createObject("roSGNode", "HttpTask")
+    m.checkCodeTask.observeField("response", "onCheckCodeMatchResponse")
+    m.checkCodeTask.url = ("/oauth2/oob/code/" + m.code)
+    m.checkCodeTask.control = "RUN"
 end sub
 
 sub onCheckCodeMatchResponse(obj)
-  m.checkCodeTask.unobserveField("response")
-  data = parseJSON(obj.getData())
+    m.checkCodeTask.unobserveField("response")
+    data = parseJSON(obj.getData())
 
-  if data.oauth_token <> invalid
-    m.top.token = data.oauth_token
-  else
-    m.timer.control = "start"
-  end if
+    if data.oauth_token <> invalid
+        m.top.token = data.oauth_token
+    else
+        m.timer.control = "start"
+    end if
 end sub
 
 function onKeyEvent(key, press)
-  if m.top.visible and press and key = "back"
-    m.top.showExitAppDialog = true
-    return true
-  end if
+    if m.top.visible and press and key = "back"
+        m.top.showExitAppDialog = true
+        return true
+    end if
 
-  return false
+    return false
 end function

--- a/components/screens/Files/FileListItem.brs
+++ b/components/screens/Files/FileListItem.brs
@@ -1,65 +1,65 @@
 function init()
-  m.icon = m.top.findNode("icon")
-  m.title = m.top.findNode("title")
-  m.description = m.top.findNode("description")
-  m.watchedEye = m.top.findNode("watchedEye")
-  m.spinner = m.top.findNode("spinner")
-  m.spinnerAnimation = m.top.FindNode("spinnerAnimation")
+    m.icon = m.top.findNode("icon")
+    m.title = m.top.findNode("title")
+    m.description = m.top.findNode("description")
+    m.watchedEye = m.top.findNode("watchedEye")
+    m.spinner = m.top.findNode("spinner")
+    m.spinnerAnimation = m.top.FindNode("spinnerAnimation")
 end function
 
 sub itemContentChanged()
-  file = m.top.itemContent.file
-  isLoading = m.top.itemContent.isLoading
-  setIcon(file)
-  setTitle(file)
-  setDescription(file)
-  setLoading(isLoading)
-  setWatchedEye(file)
+    file = m.top.itemContent.file
+    isLoading = m.top.itemContent.isLoading
+    setIcon(file)
+    setTitle(file)
+    setDescription(file)
+    setLoading(isLoading)
+    setWatchedEye(file)
 end sub
 
 sub setTitle(file)
-  m.title.text = file.name
+    m.title.text = file.name
 end sub
 
 sub setDescription(file)
-  size = convertSize(file.size)
-  date = convertDate(file.created_at)
-  m.description.text = size + " - " + date
+    size = convertSize(file.size)
+    date = convertDate(file.created_at)
+    m.description.text = size + " - " + date
 end sub
 
 sub setIcon(file)
-  fileType = file.file_type
-  iconFileName = "file_type_other.png"
-  iconMap = {
-    FOLDER: "file_type_folder.png"
-    VIDEO: "file_type_video.png"
-    AUDIO: "file_type_audio.png"
-    IMAGE: "file_type_image.png"
-    TEXT: "file_type_text.png"
-  }
+    fileType = file.file_type
+    iconFileName = "file_type_other.png"
+    iconMap = {
+        FOLDER: "file_type_folder.png"
+        VIDEO: "file_type_video.png"
+        AUDIO: "file_type_audio.png"
+        IMAGE: "file_type_image.png"
+        TEXT: "file_type_text.png"
+    }
 
-  if iconMap[fileType] <> invalid
-    iconFileName = iconMap[fileType]
-  end if
+    if iconMap[fileType] <> invalid
+        iconFileName = iconMap[fileType]
+    end if
 
-  iconFolderPath = "pkg:/images/icons/"
-  m.icon.uri = iconFolderPath + iconFileName
+    iconFolderPath = "pkg:/images/icons/"
+    m.icon.uri = iconFolderPath + iconFileName
 end sub
 
 sub setWatchedEye(file)
-  if file.start_from <> invalid and file.start_from > 0
-    m.watchedEye.visible = "true"
-  else
-    m.watchedEye.visible = "false"
-  end if
+    if file.start_from <> invalid and file.start_from > 0
+        m.watchedEye.visible = "true"
+    else
+        m.watchedEye.visible = "false"
+    end if
 end sub
 
 sub setLoading(isLoading)
-  if isLoading = true
-    m.spinner.visible = "true"
-    m.spinnerAnimation.control = "start"
-  else
-    m.spinner.visible = "false"
-    m.spinnerAnimation.control = "stop"
-  end if
+    if isLoading = true
+        m.spinner.visible = "true"
+        m.spinnerAnimation.control = "start"
+    else
+        m.spinner.visible = "false"
+        m.spinnerAnimation.control = "stop"
+    end if
 end sub

--- a/components/screens/Files/Files.brs
+++ b/components/screens/Files/Files.brs
@@ -116,7 +116,7 @@ sub onFileSelected(obj)
       navigateToFile(file)
     end if
   else
-    showFileNotSupportedDialog()
+    showFileNotSupportedDialog(onFileNotSupportedDialogClosed)
   end if
 end sub
 

--- a/components/screens/Files/Files.brs
+++ b/components/screens/Files/Files.brs
@@ -1,179 +1,179 @@
 function init()
-  m.storage = CreateObject("roRegistrySection", "userConfig")
+    m.storage = CreateObject("roRegistrySection", "userConfig")
 
-  m.top.observeField("visible", "onVisibleChange")
+    m.top.observeField("visible", "onVisibleChange")
 
-  m.parent = {}
-  m.files = []
-  m.breadcrumbs = []
+    m.parent = {}
+    m.files = []
+    m.breadcrumbs = []
 
-  m.fileList = m.top.findNode("fileList")
-  m.fileList.observeField("itemSelected", "onFileSelected")
+    m.fileList = m.top.findNode("fileList")
+    m.fileList.observeField("itemSelected", "onFileSelected")
 
-  m.fetchFilesTask = createObject("roSGNode", "HttpTask")
+    m.fetchFilesTask = createObject("roSGNode", "HttpTask")
 end function
 
 sub onVisibleChange()
-  if m.top.visible
-    m.fileList.setFocus(true)
+    if m.top.visible
+        m.fileList.setFocus(true)
 
-    if m.parent.id <> m.top.params.fileId
-      fetchWithLoader(m.top.params.fileId)
+        if m.parent.id <> m.top.params.fileId
+            fetchWithLoader(m.top.params.fileId)
+        end if
+    else
+        m.fetchFilesTask.unobserveField("response")
     end if
-  else
-    m.fetchFilesTask.unobserveField("response")
-  end if
 end sub
 
 sub fetchWithLoader(fileId)
-  hideFileList()
-  showLoading()
-  fetchFiles(fileId)
+    hideFileList()
+    showLoading()
+    fetchFiles(fileId)
 end sub
 
 sub fetchFiles(parentId)
-  m.fetchFilesTask = createObject("roSGNode", "HttpTask")
-  m.fetchFilesTask.observeField("response", "onFetchFilesResponse")
-  m.fetchFilesTask.url = ("/files/list?parent_id=" + parentId.toStr() + "&breadcrumbs=1")
-  if toBool(m.storage.read("show_only_media_files"))
-    m.fetchFilesTask.url = (m.fetchFilesTask.url + "&file_type=FOLDER,AUDIO,VIDEO,IMAGE")
-  end if
-  m.fetchFilesTask.method = "GET"
-  m.fetchFilesTask.control = "RUN"
+    m.fetchFilesTask = createObject("roSGNode", "HttpTask")
+    m.fetchFilesTask.observeField("response", "onFetchFilesResponse")
+    m.fetchFilesTask.url = ("/files/list?parent_id=" + parentId.toStr() + "&breadcrumbs=1")
+    if toBool(m.storage.read("show_only_media_files"))
+        m.fetchFilesTask.url = (m.fetchFilesTask.url + "&file_type=FOLDER,AUDIO,VIDEO,IMAGE")
+    end if
+    m.fetchFilesTask.method = "GET"
+    m.fetchFilesTask.control = "RUN"
 end sub
 
 sub onFetchFilesResponse(obj)
-  m.fetchFilesTask.unobserveField("response")
-  data = parseJSON(obj.getData())
+    m.fetchFilesTask.unobserveField("response")
+    data = parseJSON(obj.getData())
 
-  if data <> invalid and data.files <> invalid
-    m.parent = data.parent
-    m.files = data.files
-    m.breadcrumbs = data.breadcrumbs
-    showFileList()
-  else
-    showFetchFilesErrorDialog(data)
-  end if
+    if data <> invalid and data.files <> invalid
+        m.parent = data.parent
+        m.files = data.files
+        m.breadcrumbs = data.breadcrumbs
+        showFileList()
+    else
+        showFetchFilesErrorDialog(data)
+    end if
 end sub
 
 ''' UI
 sub showLoading()
-  m.top.findNode("loading").visible = "true"
+    m.top.findNode("loading").visible = "true"
 end sub
 
 sub hideLoading()
-  m.top.findNode("loading").visible = "false"
+    m.top.findNode("loading").visible = "false"
 end sub
 
 sub showFileList()
-  overhang = m.top.findNode("overhang")
-  overhang.title = m.parent.name
+    overhang = m.top.findNode("overhang")
+    overhang.title = m.parent.name
 
-  content = createObject("roSGNode", "ContentNode")
+    content = createObject("roSGNode", "ContentNode")
 
-  forIndex = 0
-  focusIndex = 0
-  for each file in m.files
-    listItemData = content.createChild("FileListItemData")
-    listItemData.file = file
+    forIndex = 0
+    focusIndex = 0
+    for each file in m.files
+        listItemData = content.createChild("FileListItemData")
+        listItemData.file = file
 
-    if file.id = m.top.params.focusFileId or file.id = m.focusFileId
-      focusIndex = forIndex
+        if file.id = m.top.params.focusFileId or file.id = m.focusFileId
+            focusIndex = forIndex
+        end if
+
+        forIndex = forIndex + 1
+    end for
+
+    m.fileList.visible = "true"
+    m.fileList.content = content
+
+    if not focusIndex = 0
+        m.fileList.jumpToItem = focusIndex
     end if
 
-    forIndex = forIndex + 1
-  end for
-
-  m.fileList.visible = "true"
-  m.fileList.content = content
-
-  if not focusIndex = 0
-    m.fileList.jumpToItem = focusIndex
-  end if
-
-  hideLoading()
- end sub
+    hideLoading()
+end sub
 
 sub hideFileList()
-  m.fileList.visible = "false"
+    m.fileList.visible = "false"
 end sub
 
 sub onFileSelected(obj)
-  fileListItem = m.fileList.content.getChild(obj.getData())
-  file = fileListItem.file
+    fileListItem = m.fileList.content.getChild(obj.getData())
+    file = fileListItem.file
 
-  if isFileSupported(file)
-    m.top.params = {
-      fileId: m.parent.id,
-      focusFileId: file.id,
-      immediateBackFileId: m.top.params.immediateBackFileId,
-    }
+    if isFileSupported(file)
+        m.top.params = {
+            fileId: m.parent.id,
+            focusFileId: file.id,
+            immediateBackFileId: m.top.params.immediateBackFileId,
+        }
 
-    if file.file_type = "FOLDER"
-      fileListItem.isLoading = true
-      fetchFiles(file.id)
+        if file.file_type = "FOLDER"
+            fileListItem.isLoading = true
+            fetchFiles(file.id)
+        else
+            navigateToFile(file)
+        end if
     else
-      navigateToFile(file)
+        showFileNotSupportedDialog(onFileNotSupportedDialogClosed)
     end if
-  else
-    showFileNotSupportedDialog(onFileNotSupportedDialogClosed)
-  end if
 end sub
 
 ''' Error Dialog
 sub showFetchFilesErrorDialog(data)
-  m.fetchFilesErrorDialog = createObject("roSGNode", "ErrorDialog")
-  m.fetchFilesErrorDialog.error = data
-  m.fetchFilesErrorDialog.observeField("wasClosed", "onFetchFilesErrorDialogClosed")
-  m.top.showDialog = m.fetchFilesErrorDialog
+    m.fetchFilesErrorDialog = createObject("roSGNode", "ErrorDialog")
+    m.fetchFilesErrorDialog.error = data
+    m.fetchFilesErrorDialog.observeField("wasClosed", "onFetchFilesErrorDialogClosed")
+    m.top.showDialog = m.fetchFilesErrorDialog
 end sub
 
 sub onFetchFilesErrorDialogClosed()
-  m.fetchFilesErrorDialog.unobserveField("wasClosed")
-  m.fileList.setFocus(true)
+    m.fetchFilesErrorDialog.unobserveField("wasClosed")
+    m.fileList.setFocus(true)
 end sub
 
 sub onFileNotSupportedDialogClosed()
-  m.fileList.setFocus(true)
+    m.fileList.setFocus(true)
 end sub
 
 ''' Delete File Dialog
 sub showDeleteFileDialog()
-  focusedFile = m.files[m.fileList.itemFocused]
+    focusedFile = m.files[m.fileList.itemFocused]
 
-  if focusedFile <> invalid
-    m.deleteFileDialog = createObject("roSGNode", "DeleteFileDialog")
-    m.deleteFileDialog.file = focusedFile
-    m.deleteFileDialog.observeField("completed", "onFileDeleted")
-    m.top.showDialog = m.deleteFileDialog
-  end if
+    if focusedFile <> invalid
+        m.deleteFileDialog = createObject("roSGNode", "DeleteFileDialog")
+        m.deleteFileDialog.file = focusedFile
+        m.deleteFileDialog.observeField("completed", "onFileDeleted")
+        m.top.showDialog = m.deleteFileDialog
+    end if
 end sub
 
 sub onFileDeleted()
-  fetchWithLoader(m.parent.id)
+    fetchWithLoader(m.parent.id)
 end sub
 
 ''' Key Handler
 function onKeyEvent(key, press)
-  if m.top.visible and press
-    if key = "back"
-      if m.top.params.immediateBackFileId = m.parent.id or m.breadcrumbs.count() = 0
-        m.top.navigateBack = "true"
-      else
-        m.focusFileId = m.parent.id
-        breadcrumb = m.breadcrumbs.pop()
-        fetchFiles(breadcrumb[0])
-      end if
+    if m.top.visible and press
+        if key = "back"
+            if m.top.params.immediateBackFileId = m.parent.id or m.breadcrumbs.count() = 0
+                m.top.navigateBack = "true"
+            else
+                m.focusFileId = m.parent.id
+                breadcrumb = m.breadcrumbs.pop()
+                fetchFiles(breadcrumb[0])
+            end if
 
-      return true
+            return true
 
-    else if key = "options"
-      showDeleteFileDialog()
-      return true
+        else if key = "options"
+            showDeleteFileDialog()
+            return true
+        end if
+
+        return false
     end if
 
     return false
-  end if
-
-  return false
 end function

--- a/components/screens/History/History.brs
+++ b/components/screens/History/History.brs
@@ -95,7 +95,7 @@ sub onHistoryItemSelected(obj)
   if canNavigateToEvent(event)
     fetchFilesAndNavigate(event.file_id)
   else
-    showFileNotSupportedDialog()
+    showFileNotSupportedDialog(onFileNotSupportedDialogClosed)
   end if
 end sub
 
@@ -118,7 +118,7 @@ sub onFetchFilesResponse(obj)
 
       navigateToFile(file, file.id)
     else
-      showFileNotSupportedDialog()
+      showFileNotSupportedDialog(onFileNotSupportedDialogClosed)
     end if
   else
     showFetchFilesErrorDialog(data)

--- a/components/screens/History/History.brs
+++ b/components/screens/History/History.brs
@@ -1,171 +1,171 @@
 function init()
-  m.storage = CreateObject("roRegistrySection", "userConfig")
+    m.storage = CreateObject("roRegistrySection", "userConfig")
 
-  m.top.observeField("visible", "onVisibleChange")
+    m.top.observeField("visible", "onVisibleChange")
 
-  m.parent = {}
-  m.history = []
-  m.breadcrumbs = []
+    m.parent = {}
+    m.history = []
+    m.breadcrumbs = []
 
-  m.historyList = m.top.findNode("historyList")
-  m.historyList.observeField("itemSelected", "onHistoryItemSelected")
+    m.historyList = m.top.findNode("historyList")
+    m.historyList.observeField("itemSelected", "onHistoryItemSelected")
 
-  m.fetchHistoryTask = createObject("roSGNode", "HttpTask")
+    m.fetchHistoryTask = createObject("roSGNode", "HttpTask")
 end function
 
 sub onVisibleChange()
-  if m.top.visible
-    m.historyList.setFocus(true)
-    if m.focusEventId = invalid
-      hideHistory()
-      showLoading()
-      fetchHistory()
+    if m.top.visible
+        m.historyList.setFocus(true)
+        if m.focusEventId = invalid
+            hideHistory()
+            showLoading()
+            fetchHistory()
+        end if
+    else
+        m.fetchHistoryTask.unobserveField("response")
     end if
-  else
-    m.fetchHistoryTask.unobserveField("response")
-  end if
 end sub
 
 sub fetchHistory()
-  m.fetchHistoryTask = createObject("roSGNode", "HttpTask")
-  m.fetchHistoryTask.observeField("response", "onFetchHistoryResponse")
-  m.fetchHistoryTask.url = "/events/list"
-  m.fetchHistoryTask.method = "GET"
-  m.fetchHistoryTask.control = "RUN"
+    m.fetchHistoryTask = createObject("roSGNode", "HttpTask")
+    m.fetchHistoryTask.observeField("response", "onFetchHistoryResponse")
+    m.fetchHistoryTask.url = "/events/list"
+    m.fetchHistoryTask.method = "GET"
+    m.fetchHistoryTask.control = "RUN"
 end sub
 
 sub onFetchHistoryResponse(obj)
-  m.fetchHistoryTask.unobserveField("response")
-  data = parseJSON(obj.getData())
+    m.fetchHistoryTask.unobserveField("response")
+    data = parseJSON(obj.getData())
 
-  if data <> invalid and data.events <> invalid
-    m.history = data.events
-    m.breadcrumbs = data.breadcrumbs
-    showHistory()
-  else
-    showFetchHistoryErrorDialog(data)
-  end if
+    if data <> invalid and data.events <> invalid
+        m.history = data.events
+        m.breadcrumbs = data.breadcrumbs
+        showHistory()
+    else
+        showFetchHistoryErrorDialog(data)
+    end if
 end sub
 
 ''' UI
 sub showLoading()
-  m.top.findNode("loading").visible = "true"
+    m.top.findNode("loading").visible = "true"
 end sub
 
 sub hideLoading()
-  m.top.findNode("loading").visible = "false"
+    m.top.findNode("loading").visible = "false"
 end sub
 
 sub showHistory()
-  content = createObject("roSGNode", "ContentNode")
+    content = createObject("roSGNode", "ContentNode")
 
-  forIndex = 0
-  focusIndex = 0
-  for each historyEvent in m.history
-    if historyEvent.type <> "zip_created"
-      listItemData = content.createChild("HistoryListItemData")
-      listItemData.event = historyEvent
+    forIndex = 0
+    focusIndex = 0
+    for each historyEvent in m.history
+        if historyEvent.type <> "zip_created"
+            listItemData = content.createChild("HistoryListItemData")
+            listItemData.event = historyEvent
 
-      if historyEvent.id = m.focusEventId
-        focusIndex = forIndex
-      end if
+            if historyEvent.id = m.focusEventId
+                focusIndex = forIndex
+            end if
 
-      forIndex = forIndex + 1
+            forIndex = forIndex + 1
+        end if
+    end for
+
+    m.historyList.visible = "true"
+    m.historyList.content = content
+
+    if not focusIndex = 0
+        m.historyList.jumpToItem = focusIndex
     end if
-  end for
 
-  m.historyList.visible = "true"
-  m.historyList.content = content
-
-  if not focusIndex = 0
-    m.historyList.jumpToItem = focusIndex
-  end if
-
-  hideLoading()
+    hideLoading()
 end sub
 
 sub hideHistory()
-  m.historyList.visible = "false"
+    m.historyList.visible = "false"
 end sub
 
 sub onHistoryItemSelected(obj)
-  historyListItem = m.historyList.content.getChild(obj.getData())
-  event = historyListItem.event
+    historyListItem = m.historyList.content.getChild(obj.getData())
+    event = historyListItem.event
 
-  if canNavigateToEvent(event)
-    fetchFilesAndNavigate(event.file_id)
-  else
-    showFileNotSupportedDialog(onFileNotSupportedDialogClosed)
-  end if
+    if canNavigateToEvent(event)
+        fetchFilesAndNavigate(event.file_id)
+    else
+        showFileNotSupportedDialog(onFileNotSupportedDialogClosed)
+    end if
 end sub
 
 sub fetchFilesAndNavigate(parentId)
-  m.fetchFilesTask = createObject("roSGNode", "HttpTask")
-  m.fetchFilesTask.observeField("response", "onFetchFilesResponse")
-  m.fetchFilesTask.url = ("/files/list?parent_id=" + parentId.toStr() + "&breadcrumbs=1")
-  m.fetchFilesTask.method = "GET"
-  m.fetchFilesTask.control = "RUN"
+    m.fetchFilesTask = createObject("roSGNode", "HttpTask")
+    m.fetchFilesTask.observeField("response", "onFetchFilesResponse")
+    m.fetchFilesTask.url = ("/files/list?parent_id=" + parentId.toStr() + "&breadcrumbs=1")
+    m.fetchFilesTask.method = "GET"
+    m.fetchFilesTask.control = "RUN"
 end sub
 
 sub onFetchFilesResponse(obj)
-  m.fetchFilesTask.unobserveField("response")
-  data = parseJSON(obj.getData())
+    m.fetchFilesTask.unobserveField("response")
+    data = parseJSON(obj.getData())
 
-  if data <> invalid and data.parent <> invalid
-    file = data.parent
-    if isFileSupported(file)
-      m.focusEventId = file.id
+    if data <> invalid and data.parent <> invalid
+        file = data.parent
+        if isFileSupported(file)
+            m.focusEventId = file.id
 
-      navigateToFile(file, file.id)
+            navigateToFile(file, file.id)
+        else
+            showFileNotSupportedDialog(onFileNotSupportedDialogClosed)
+        end if
     else
-      showFileNotSupportedDialog(onFileNotSupportedDialogClosed)
+        showFetchFilesErrorDialog(data)
     end if
-  else
-    showFetchFilesErrorDialog(data)
-  end if
 end sub
 
 ''' Error Dialog
 sub showFetchFilesErrorDialog(data)
-  m.fetchFilesErrorDialog = createObject("roSGNode", "ErrorDialog")
-  m.fetchFilesErrorDialog.error = data
-  m.fetchFilesErrorDialog.observeField("wasClosed", "onFetchFilesErrorDialogClosed")
-  m.top.showDialog = m.fetchFilesErrorDialog
+    m.fetchFilesErrorDialog = createObject("roSGNode", "ErrorDialog")
+    m.fetchFilesErrorDialog.error = data
+    m.fetchFilesErrorDialog.observeField("wasClosed", "onFetchFilesErrorDialogClosed")
+    m.top.showDialog = m.fetchFilesErrorDialog
 end sub
 
 
-sub canNavigateToEvent(event) as Boolean
-  return event.type = "upload" or event.type = "file_shared" or event.type = "transfer_completed"
+sub canNavigateToEvent(event) as boolean
+    return event.type = "upload" or event.type = "file_shared" or event.type = "transfer_completed"
 end sub
 
 ''' Error Dialog
 sub showFetchHistoryErrorDialog(data)
-  m.fetchHistoryErrorDialog = createObject("roSGNode", "ErrorDialog")
-  m.fetchHistoryErrorDialog.error = data
-  m.fetchHistoryErrorDialog.observeField("wasClosed", "onFetchHistoryErrorDialogClosed")
-  m.top.showDialog = m.fetchHistoryErrorDialog
+    m.fetchHistoryErrorDialog = createObject("roSGNode", "ErrorDialog")
+    m.fetchHistoryErrorDialog.error = data
+    m.fetchHistoryErrorDialog.observeField("wasClosed", "onFetchHistoryErrorDialogClosed")
+    m.top.showDialog = m.fetchHistoryErrorDialog
 end sub
 
 sub onFetchHistoryErrorDialogClosed()
-  m.fetchHistoryErrorDialog.unobserveField("wasClosed")
-  m.historyList.setFocus(true)
+    m.fetchHistoryErrorDialog.unobserveField("wasClosed")
+    m.historyList.setFocus(true)
 end sub
 
 sub onFileNotSupportedDialogClosed()
-  m.historyList.setFocus(true)
+    m.historyList.setFocus(true)
 end sub
 
 ''' Key Handler
 function onKeyEvent(key, press)
-  if m.top.visible and press
-    if key = "back"
-      m.focusEventId = invalid
-      m.top.navigateBack = "true"
-      return true
+    if m.top.visible and press
+        if key = "back"
+            m.focusEventId = invalid
+            m.top.navigateBack = "true"
+            return true
+        end if
+
+        return false
     end if
 
     return false
-  end if
-
-  return false
 end function

--- a/components/screens/History/HistoryEvents.brs
+++ b/components/screens/History/HistoryEvents.brs
@@ -1,175 +1,175 @@
-sub SubtitleWithDate(createdAt, subtitleText = invalid) as String
-  date = convertDate(createdAt)
-  if subtitleText <> invalid
-    return date + " - " + subtitleText
-  end if
-  return date
+sub SubtitleWithDate(createdAt, subtitleText = invalid) as string
+    date = convertDate(createdAt)
+    if subtitleText <> invalid
+        return date + " - " + subtitleText
+    end if
+    return date
 end sub
 
 ' Upload
-sub HistoryEventUploadTitle(event) as String
-  return "You've uploaded " + event.file_name
+sub HistoryEventUploadTitle(event) as string
+    return "You've uploaded " + event.file_name
 end sub
 
-sub HistoryEventUploadDescription(event) as String
-  size = convertSize(event.file_size)
-  return SubtitleWithDate(event.created_at, size)
+sub HistoryEventUploadDescription(event) as string
+    size = convertSize(event.file_size)
+    return SubtitleWithDate(event.created_at, size)
 end sub
 
 ' File shared
-sub HistoryEventFileSharedTitle(event) as String
-  return event.file_name
+sub HistoryEventFileSharedTitle(event) as string
+    return event.file_name
 end sub
 
-sub HistoryEventFileSharedDescription(event) as String
-  return SubtitleWithDate(event.created_at, "shared by " + event.sharing_user_name)
+sub HistoryEventFileSharedDescription(event) as string
+    return SubtitleWithDate(event.created_at, "shared by " + event.sharing_user_name)
 end sub
 
 ' Transfer completed
-sub HistoryEventTransferCompletedTitle(event) as String
-  return event.transfer_name
+sub HistoryEventTransferCompletedTitle(event) as string
+    return event.transfer_name
 end sub
 
-sub HistoryEventTransferCompletedDescription(event) as String
-  size = convertSize(event.transfer_size)
-  return SubtitleWithDate(event.created_at, size)
+sub HistoryEventTransferCompletedDescription(event) as string
+    size = convertSize(event.transfer_size)
+    return SubtitleWithDate(event.created_at, size)
 end sub
 
 ' Transfer rrror
-sub HistoryEventTransferErrorTitle(event) as String
-  return "Error in transfer " + event.transfer_name
+sub HistoryEventTransferErrorTitle(event) as string
+    return "Error in transfer " + event.transfer_name
 end sub
 
-sub HistoryEventTransferErrorDescription(event) as String
-  return SubtitleWithDate(event.created_at)
+sub HistoryEventTransferErrorDescription(event) as string
+    return SubtitleWithDate(event.created_at)
 end sub
 
 ' File from RSS deleted
-sub HistoryEventFileFromRSSDeletedTitle(event) as String
-  return "We had to delete " + event.file_name + " per your instructions, since there wasn't enough free space."
+sub HistoryEventFileFromRSSDeletedTitle(event) as string
+    return "We had to delete " + event.file_name + " per your instructions, since there wasn't enough free space."
 end sub
 
-sub HistoryEventFileFromRSSDeletedDescription(event) as String
-  size = convertSize(event.file_size)
-  return SubtitleWithDate(size)
+sub HistoryEventFileFromRSSDeletedDescription(event) as string
+    size = convertSize(event.file_size)
+    return SubtitleWithDate(size)
 end sub
 
 ' RSS paused
-sub HistoryEventRSSPausedTitle(event) as String
-  return event.rss_filter_title + " is paused because we couldn't reach the source"
+sub HistoryEventRSSPausedTitle(event) as string
+    return event.rss_filter_title + " is paused because we couldn't reach the source"
 end sub
 
-sub HistoryEventRSSPausedDescription(event) as String
-  return SubtitleWithDate(event.created_at)
+sub HistoryEventRSSPausedDescription(event) as string
+    return SubtitleWithDate(event.created_at)
 end sub
 
 ' Transfer from RSS error
-sub HistoryEventRSSTransferErrorTitle(event) as String
-  return "Error in transfer from RSS for " + event.transfer_name
+sub HistoryEventRSSTransferErrorTitle(event) as string
+    return "Error in transfer from RSS for " + event.transfer_name
 end sub
 
-sub HistoryEventRSSTransferErrorDescription(event) as String
-  return SubtitleWithDate(event.created_at)
+sub HistoryEventRSSTransferErrorDescription(event) as string
+    return SubtitleWithDate(event.created_at)
 end sub
 
 'Transfer callback error
-sub HistoryEventTransferCallbackErrorTitle(event) as String
-  return "Error in transfer callback for " + event.transfer_name
+sub HistoryEventTransferCallbackErrorTitle(event) as string
+    return "Error in transfer callback for " + event.transfer_name
 end sub
 
-sub HistoryEventTransferCallbackErrorDescription(event) as String
-  return SubtitleWithDate(event.created_at, event.message)
+sub HistoryEventTransferCallbackErrorDescription(event) as string
+    return SubtitleWithDate(event.created_at, event.message)
 end sub
 
 ' Private torrent pin
-sub HistoryEventPrivateTorrentPinTitle(event) as String
-  return "Your private IP `" + event.pinned_host_ip + "` was temporarily down, we had to use `" + event.new_host_ip + "` for " + event.user_download_name
+sub HistoryEventPrivateTorrentPinTitle(event) as string
+    return "Your private IP `" + event.pinned_host_ip + "` was temporarily down, we had to use `" + event.new_host_ip + "` for " + event.user_download_name
 end sub
 
-sub HistoryEventPrivateTorrentPinDescription(event) as String
-  return SubtitleWithDate(event.created_at)
+sub HistoryEventPrivateTorrentPinDescription(event) as string
+    return SubtitleWithDate(event.created_at)
 end sub
 
 ' Voucher
-sub HistoryEventVoucherTitle(event) as String
-  return "Hey there. Welcome to put.io. We've made you and " + event.voucher_owner_name + " friends. You can see their shares now."
+sub HistoryEventVoucherTitle(event) as string
+    return "Hey there. Welcome to put.io. We've made you and " + event.voucher_owner_name + " friends. You can see their shares now."
 end sub
 
-sub HistoryEventVoucherDescription(event) as String
-  return SubtitleWithDate(event.created_at)
+sub HistoryEventVoucherDescription(event) as string
+    return SubtitleWithDate(event.created_at)
 end sub
 
 ' Default - Any
-sub HistoryEventAnyTitle(event) as String
-  return event.type
+sub HistoryEventAnyTitle(event) as string
+    return event.type
 end sub
 
-sub HistoryEventAnyDescription(event) as String
-  return SubtitleWithDate(event.created_at)
+sub HistoryEventAnyDescription(event) as string
+    return SubtitleWithDate(event.created_at)
 end sub
 
 ' Map
-sub GetMapFromHistoryEventType(eventType) as Object
-  eventMap = {
-      upload: {
-        title: HistoryEventUploadTitle,
-        description: HistoryEventUploadDescription,
-        icon: "cloud-upload-1",
-      },
-      file_shared: {
-        title: HistoryEventFileSharedTitle,
-        description: HistoryEventFileSharedDescription,
-        icon: "cloud-add-1",
-      },
-      transfer_completed: {
-        title: HistoryEventTransferCompletedTitle,
-        description: HistoryEventTransferCompletedDescription,
-        icon: "media-gallery-1",
-      },
-      transfer_error: {
-        title: HistoryEventTransferErrorTitle,
-        description: HistoryEventTransferErrorDescription,
-        icon: "x-2-red",
-      },
-      file_from_rss_deleted_for_space: {
-        title: HistoryEventFileFromRSSDeletedTitle,
-        description: HistoryEventFileFromRSSDeletedDescription,
-        icon: "exclamation-point-1",
-      },
-      rss_filter_paused: {
-        title: HistoryEventRSSPausedDescription,
-        description: HistoryEventRSSPausedDescription,
-        icon: "rss-1",
-      },
-      transfer_from_rss_error: {
-        title: HistoryEventRSSTransferErrorTitle,
-        description: HistoryEventRSSTransferErrorDescription,
-        icon: "x-2-red",
-      },
-      transfer_callback_error: {
-        title: HistoryEventTransferCallbackErrorTitle,
-        description: HistoryEventTransferCallbackErrorDescription,
-        icon: "x-2-red",
-      },
-      private_torrent_pin: {
-        title: HistoryEventPrivateTorrentPinTitle,
-        description: HistoryEventPrivateTorrentPinDescription,
-        icon: "exclamation-point-1",
-      },
-      voucher: {
-        title: HistoryEventVoucherTitle,
-        description: HistoryEventVoucherDescription,
-        icon: "user-1",
-      }
-  }
+sub GetMapFromHistoryEventType(eventType) as object
+    eventMap = {
+        upload: {
+            title: HistoryEventUploadTitle,
+            description: HistoryEventUploadDescription,
+            icon: "cloud-upload-1",
+        },
+        file_shared: {
+            title: HistoryEventFileSharedTitle,
+            description: HistoryEventFileSharedDescription,
+            icon: "cloud-add-1",
+        },
+        transfer_completed: {
+            title: HistoryEventTransferCompletedTitle,
+            description: HistoryEventTransferCompletedDescription,
+            icon: "media-gallery-1",
+        },
+        transfer_error: {
+            title: HistoryEventTransferErrorTitle,
+            description: HistoryEventTransferErrorDescription,
+            icon: "x-2-red",
+        },
+        file_from_rss_deleted_for_space: {
+            title: HistoryEventFileFromRSSDeletedTitle,
+            description: HistoryEventFileFromRSSDeletedDescription,
+            icon: "exclamation-point-1",
+        },
+        rss_filter_paused: {
+            title: HistoryEventRSSPausedDescription,
+            description: HistoryEventRSSPausedDescription,
+            icon: "rss-1",
+        },
+        transfer_from_rss_error: {
+            title: HistoryEventRSSTransferErrorTitle,
+            description: HistoryEventRSSTransferErrorDescription,
+            icon: "x-2-red",
+        },
+        transfer_callback_error: {
+            title: HistoryEventTransferCallbackErrorTitle,
+            description: HistoryEventTransferCallbackErrorDescription,
+            icon: "x-2-red",
+        },
+        private_torrent_pin: {
+            title: HistoryEventPrivateTorrentPinTitle,
+            description: HistoryEventPrivateTorrentPinDescription,
+            icon: "exclamation-point-1",
+        },
+        voucher: {
+            title: HistoryEventVoucherTitle,
+            description: HistoryEventVoucherDescription,
+            icon: "user-1",
+        }
+    }
 
-  if eventMap.doesExist(eventType) and eventMap[eventType] <> invalid
-    return eventMap[eventType]
-  end if
-  
-  return {
-    title: HistoryEventAnyTitle,
-    description: HistoryEventAnyDescription,
-    icon: "x-2",
-  }
+    if eventMap.doesExist(eventType) and eventMap[eventType] <> invalid
+        return eventMap[eventType]
+    end if
+
+    return {
+        title: HistoryEventAnyTitle,
+        description: HistoryEventAnyDescription,
+        icon: "x-2",
+    }
 end sub

--- a/components/screens/History/HistoryListItem.brs
+++ b/components/screens/History/HistoryListItem.brs
@@ -1,30 +1,30 @@
 function init()
-  m.icon = m.top.findNode("icon")
-  m.title = m.top.findNode("title")
-  m.description = m.top.findNode("description")
-  m.spinner = m.top.findNode("spinner")
-  m.spinnerAnimation = m.top.FindNode("spinnerAnimation")
+    m.icon = m.top.findNode("icon")
+    m.title = m.top.findNode("title")
+    m.description = m.top.findNode("description")
+    m.spinner = m.top.findNode("spinner")
+    m.spinnerAnimation = m.top.FindNode("spinnerAnimation")
 end function
 
 sub itemContentChanged()
-  event = m.top.itemContent.event
-  isLoading = m.top.itemContent.isLoading
-  contentMap = GetMapFromHistoryEventType(event.type)
-  m.title.text = contentMap.title(event)
-  m.description.text = contentMap.description(event)
-  if contentMap.icon <> invalid
-    iconFolderPath = "pkg:/images/icons/"
-    m.icon.uri = iconFolderPath + contentMap.icon + ".png" 'iconFileName
-  end if
-  setLoading(isLoading)
+    event = m.top.itemContent.event
+    isLoading = m.top.itemContent.isLoading
+    contentMap = GetMapFromHistoryEventType(event.type)
+    m.title.text = contentMap.title(event)
+    m.description.text = contentMap.description(event)
+    if contentMap.icon <> invalid
+        iconFolderPath = "pkg:/images/icons/"
+        m.icon.uri = iconFolderPath + contentMap.icon + ".png" 'iconFileName
+    end if
+    setLoading(isLoading)
 end sub
 
 sub setLoading(isLoading)
-  if isLoading = true
-    m.spinner.visible = "true"
-    m.spinnerAnimation.control = "start"
-  else
-    m.spinner.visible = "false"
-    m.spinnerAnimation.control = "stop"
-  end if
+    if isLoading = true
+        m.spinner.visible = "true"
+        m.spinnerAnimation.control = "start"
+    else
+        m.spinner.visible = "false"
+        m.spinnerAnimation.control = "stop"
+    end if
 end sub

--- a/components/screens/Home/Home.brs
+++ b/components/screens/Home/Home.brs
@@ -97,4 +97,6 @@ function onKeyEvent(key, press)
     m.top.showExitAppDialog = true
     return true
   end if
+
+  return false
 end function

--- a/components/screens/Home/Home.brs
+++ b/components/screens/Home/Home.brs
@@ -1,102 +1,102 @@
 function init()
-  m.top.observeField("visible", "onVisibleChange")
-  m.global.observeField("user", "modifyList")
+    m.top.observeField("visible", "onVisibleChange")
+    m.global.observeField("user", "modifyList")
 
-  m.list = m.top.findNode("list")
-  m.list.observeField("itemSelected", "onListItemSelected")
+    m.list = m.top.findNode("list")
+    m.list.observeField("itemSelected", "onListItemSelected")
 
-  m.items = [
-    {
-      key: "files",
-      title: "Your Files",
-      iconName: "file_type_folder",
-    },
-    {
-      key: "search",
-      title: "Search",
-      iconName: "search",
-    },
-    {
-      key: "history",
-      title: "History",
-      iconName: "history-1",
-      isEnabled: false
-    },
-    {
-      key: "settings",
-      title: "Settings",
-      iconName: "settings",
-    }
-  ]
-  renderList()
+    m.items = [
+        {
+            key: "files",
+            title: "Your Files",
+            iconName: "file_type_folder",
+        },
+        {
+            key: "search",
+            title: "Search",
+            iconName: "search",
+        },
+        {
+            key: "history",
+            title: "History",
+            iconName: "history-1",
+            isEnabled: false
+        },
+        {
+            key: "settings",
+            title: "Settings",
+            iconName: "settings",
+        }
+    ]
+    renderList()
 end function
 
 sub onVisibleChange()
-  if m.top.visible
-    m.list.setFocus(true)
-  end if
+    if m.top.visible
+        m.list.setFocus(true)
+    end if
 end sub
 
 sub modifyList()
-  if m.global.user.settings.doesExist("history_enabled")
-    m.items[2].isEnabled = m.global.user.settings.history_enabled
-    renderList()
-  end if
+    if m.global.user.settings.doesExist("history_enabled")
+        m.items[2].isEnabled = m.global.user.settings.history_enabled
+        renderList()
+    end if
 end sub
 
 sub renderList()
-  content = createObject("roSGNode", "ContentNode")
+    content = createObject("roSGNode", "ContentNode")
 
-  for i = 0 to m.items.count() - 1
-    item = m.items[i]
-    if item.isEnabled = invalid or (item.isEnabled <> invalid and item.isEnabled)
-      listItemData = content.createChild("ListItemData")
-      listItemData.key = item.key
-      listItemData.title = item.title
-      listItemData.iconName = item.iconName
-    end if
-  end for
+    for i = 0 to m.items.count() - 1
+        item = m.items[i]
+        if item.isEnabled = invalid or (item.isEnabled <> invalid and item.isEnabled)
+            listItemData = content.createChild("ListItemData")
+            listItemData.key = item.key
+            listItemData.title = item.title
+            listItemData.iconName = item.iconName
+        end if
+    end for
 
-  m.list.content = content
+    m.list.content = content
 end sub
 
 sub onListItemSelected(obj)
-  key = m.list.content.getChild(obj.getData()).key
+    key = m.list.content.getChild(obj.getData()).key
 
-  if key = "search"
-    m.top.navigate = {
-      id: "searchScreen",
-      params: {}
-    }
+    if key = "search"
+        m.top.navigate = {
+            id: "searchScreen",
+            params: {}
+        }
 
-  else if key = "files"
-    m.top.navigate = {
-      id: "filesScreen"
-      params: {
-        fileId: 0
-      }
-    }
+    else if key = "files"
+        m.top.navigate = {
+            id: "filesScreen"
+            params: {
+                fileId: 0
+            }
+        }
 
-  else if key = "settings"
-    m.top.navigate = {
-      id: "settingsScreen",
-      params: {},
-    }
-  
-  else if key = "history"
-    m.top.navigate = {
-      id: "historyScreen",
-      params: {},
-    }
+    else if key = "settings"
+        m.top.navigate = {
+            id: "settingsScreen",
+            params: {},
+        }
 
-  end if
+    else if key = "history"
+        m.top.navigate = {
+            id: "historyScreen",
+            params: {},
+        }
+
+    end if
 end sub
 
 function onKeyEvent(key, press)
-  if m.top.visible and press and key = "back"
-    m.top.showExitAppDialog = true
-    return true
-  end if
+    if m.top.visible and press and key = "back"
+        m.top.showExitAppDialog = true
+        return true
+    end if
 
-  return false
+    return false
 end function

--- a/components/screens/Image/Image.brs
+++ b/components/screens/Image/Image.brs
@@ -1,52 +1,52 @@
 function init()
-  m.top.observeField("visible", "onVisibleChange")
+    m.top.observeField("visible", "onVisibleChange")
 
-  m.image = m.top.findNode("image")
-  m.loading = m.top.findNode("loading")
-  m.overhang = m.top.findNode("overhang")
+    m.image = m.top.findNode("image")
+    m.loading = m.top.findNode("loading")
+    m.overhang = m.top.findNode("overhang")
 
-  m.image.observeField("loadStatus", "onImageLoad")
+    m.image.observeField("loadStatus", "onImageLoad")
 end function
 
 sub onVisibleChange()
-  if m.top.visible
-    m.image.visible = "false"
-    m.loading.visible = "true"
-    m.image.uri = (m.global.apiURL + "/files/" + m.top.params.fileId.toStr() + "/download?oauth_token=" + m.global.user.download_token.toStr() + "")
-    m.overhang.title = m.top.params.fileName
-  else
-    m.image.uri = ""
-  end if
+    if m.top.visible
+        m.image.visible = "false"
+        m.loading.visible = "true"
+        m.image.uri = (m.global.apiURL + "/files/" + m.top.params.fileId.toStr() + "/download?oauth_token=" + m.global.user.download_token.toStr() + "")
+        m.overhang.title = m.top.params.fileName
+    else
+        m.image.uri = ""
+    end if
 end sub
 
 sub onImageLoad()
-  if m.image.loadStatus = "ready"
-    m.loading.visible = "false"
-    m.image.visible = "true"
-  else if m.image.loadStatus = "failed"
-    showImageErrorDialog()
-  end if
+    if m.image.loadStatus = "ready"
+        m.loading.visible = "false"
+        m.image.visible = "true"
+    else if m.image.loadStatus = "failed"
+        showImageErrorDialog()
+    end if
 end sub
 
 sub onImageLoadErrorDialogClosed()
-  m.top.navigateBack = "true"
+    m.top.navigateBack = "true"
 end sub
 
 sub showImageErrorDialog()
-  m.imageLoadErrorDialog = createObject("roSGNode", "ErrorDialog")
-  m.imageLoadErrorDialog.title = "Oops :("
-  m.imageLoadErrorDialog.message = "This image can not be loaded!"
-  m.imageLoadErrorDialog.observeField("wasClosed", "onImageLoadErrorDialogClosed")
-  m.top.showDialog = m.imageLoadErrorDialog
+    m.imageLoadErrorDialog = createObject("roSGNode", "ErrorDialog")
+    m.imageLoadErrorDialog.title = "Oops :("
+    m.imageLoadErrorDialog.message = "This image can not be loaded!"
+    m.imageLoadErrorDialog.observeField("wasClosed", "onImageLoadErrorDialogClosed")
+    m.top.showDialog = m.imageLoadErrorDialog
 end sub
 
 function onKeyEvent(key, press)
-  if m.top.visible and press
-    if key = "back"
-      m.top.navigateBack = "true"
-      return true
+    if m.top.visible and press
+        if key = "back"
+            m.top.navigateBack = "true"
+            return true
+        end if
     end if
-  end if
 
-  return false
+    return false
 end function

--- a/components/screens/Search/Search.brs
+++ b/components/screens/Search/Search.brs
@@ -43,7 +43,7 @@ sub setSearchHistory(text)
 end sub
 
 sub updateSearchHistoryButtons(keyword)
-  if m.keyboard.text.Len() = 0
+  if keyword = invalid or keyword.Len() = 0
     m.searchResultGroup.insertChild(m.searchHistory, 0)
     content = createObject("roSGNode", "ContentNode")
     for each historyItem in getSearchHistory()
@@ -117,7 +117,7 @@ sub onFileSelected(obj)
     setSearchHistory(m.keyboard.text)
     navigateToFile(file)
   else
-    showFileNotSupportedDialog()
+    showFileNotSupportedDialog(onFileNotSupportedDialogClosed)
   end if
 end sub
 
@@ -183,7 +183,7 @@ sub putSearchHistory(historyItems)
   m.putSearchHistory.control = "RUN"
 end sub
 
-sub onPutSearchHistory(obj)
+sub onPutSearchHistory()
   m.putSearchHistory.unobserveField("response")
   ' if there is an error, just skip
   fetchSearchHistory()

--- a/components/screens/Search/Search.brs
+++ b/components/screens/Search/Search.brs
@@ -1,237 +1,237 @@
 function init()
-  m.storage = CreateObject("roRegistrySection", "userConfig")
-  m.top.observeField("visible", "onVisibleChange")
+    m.storage = CreateObject("roRegistrySection", "userConfig")
+    m.top.observeField("visible", "onVisibleChange")
 
-  m.keyboard = m.top.findNode("keyboard")
-  m.keyboard.setFocus(true)
-  m.keyboard.observeField("text", "onKeywordChange")
+    m.keyboard = m.top.findNode("keyboard")
+    m.keyboard.setFocus(true)
+    m.keyboard.observeField("text", "onKeywordChange")
 
-  m.loading = m.top.findNode("loading")
-  m.searchFileList = m.top.findNode("searchFileList")
-  m.searchFileList.observeField("itemSelected", "onFileSelected")
-  m.searchFileList.visible = false
+    m.loading = m.top.findNode("loading")
+    m.searchFileList = m.top.findNode("searchFileList")
+    m.searchFileList.observeField("itemSelected", "onFileSelected")
+    m.searchFileList.visible = false
 
-  m.searchTask = createObject("roSGNode", "HttpTask")
-  m.files = []
+    m.searchTask = createObject("roSGNode", "HttpTask")
+    m.files = []
 
-  m.searchResultGroup = m.top.findNode("searchResultGroup")
+    m.searchResultGroup = m.top.findNode("searchResultGroup")
 
-  m.searchHistory = m.top.findNode("searchHistory")
-  m.searchHistory.observeField("itemSelected", "onHistoryItemSelected")
+    m.searchHistory = m.top.findNode("searchHistory")
+    m.searchHistory.observeField("itemSelected", "onHistoryItemSelected")
 
-  m.fetchSearchHistory = createObject("roSGNode", "HttpTask")
-  m.putSearchHistory = createObject("roSGNode", "HttpTask")
+    m.fetchSearchHistory = createObject("roSGNode", "HttpTask")
+    m.putSearchHistory = createObject("roSGNode", "HttpTask")
 end function
 
 function getSearchHistory()
-  return m.searchHistoryItems
+    return m.searchHistoryItems
 end function
 
 sub setSearchHistory(text)
-  historyItems = getSearchHistory()
-  historyItemsTemp = CreateObject("roArray", historyItems.Count(), true)
+    historyItems = getSearchHistory()
+    historyItemsTemp = CreateObject("roArray", historyItems.Count(), true)
 
-  historyItemsTemp.Push(text)
-  for each historyItem in historyItems
-    if historyItem <> text and historyItemsTemp.Count() < 6
-      historyItemsTemp.Push(historyItem)
-    end if
-  end for
+    historyItemsTemp.Push(text)
+    for each historyItem in historyItems
+        if historyItem <> text and historyItemsTemp.Count() < 6
+            historyItemsTemp.Push(historyItem)
+        end if
+    end for
 
-  m.searchHistoryItems = historyItemsTemp
-  putSearchHistory(m.searchHistoryItems)
+    m.searchHistoryItems = historyItemsTemp
+    putSearchHistory(m.searchHistoryItems)
 end sub
 
 sub updateSearchHistoryButtons(keyword)
-  if keyword = invalid or keyword.Len() = 0
-    m.searchResultGroup.insertChild(m.searchHistory, 0)
-    content = createObject("roSGNode", "ContentNode")
-    for each historyItem in getSearchHistory()
-      label = content.createChild("ContentNode")
-      label.title = historyItem
-    end for
+    if keyword = invalid or keyword.Len() = 0
+        m.searchResultGroup.insertChild(m.searchHistory, 0)
+        content = createObject("roSGNode", "ContentNode")
+        for each historyItem in getSearchHistory()
+            label = content.createChild("ContentNode")
+            label.title = historyItem
+        end for
 
-    m.searchHistory.content = content
-    m.searchHistory.visible = true
-  else
-    m.searchResultGroup.removeChild(m.searchHistory)
-    m.searchHistory.visible = false
-  end if
-  ' STOP
+        m.searchHistory.content = content
+        m.searchHistory.visible = true
+    else
+        m.searchResultGroup.removeChild(m.searchHistory)
+        m.searchHistory.visible = false
+    end if
+    ' STOP
 end sub
 
 sub onVisibleChange()
-  if m.top.visible
-    if m.keyboard.text = "" or m.keyboard.text = invalid
-      fetchSearchHistory()
+    if m.top.visible
+        if m.keyboard.text = "" or m.keyboard.text = invalid
+            fetchSearchHistory()
+        end if
+        m.keyboard.setFocus(true)
+        updateSearchHistoryButtons(m.keyboard.text)
     end if
-    m.keyboard.setFocus(true)
-    updateSearchHistoryButtons(m.keyboard.text)
-  end if
 end sub
 
 sub onKeywordChange(obj)
-  keyword = obj.getData()
-  updateSearchHistoryButtons(keyword)
+    keyword = obj.getData()
+    updateSearchHistoryButtons(keyword)
 
-  if keyword <> invalid and len(keyword) > 0
-    showLoading()
-    onSearch(keyword)
-  else
-    m.files = []
-    configureFileList()
-  end if
+    if keyword <> invalid and len(keyword) > 0
+        showLoading()
+        onSearch(keyword)
+    else
+        m.files = []
+        configureFileList()
+    end if
 end sub
 
 sub onSearch(keyword)
-  m.searchTask.observeField("response", "onSearchResponse")
-  if toBool(m.storage.read("show_only_media_files"))
-    keyword = (keyword + " type:FOLDER,AUDIO,VIDEO,IMAGE")
-  end if
-  m.searchTask.url = "/files/search/" + keyword.encodeUri() + "/page/1"
-  m.searchTask.method = "GET"
-  m.searchTask.control = "RUN"
+    m.searchTask.observeField("response", "onSearchResponse")
+    if toBool(m.storage.read("show_only_media_files"))
+        keyword = (keyword + " type:FOLDER,AUDIO,VIDEO,IMAGE")
+    end if
+    m.searchTask.url = "/files/search/" + keyword.encodeUri() + "/page/1"
+    m.searchTask.method = "GET"
+    m.searchTask.control = "RUN"
 end sub
 
 sub onSearchResponse(obj)
-  m.searchTask.unobserveField("response")
-  data = parseJSON(obj.getData())
+    m.searchTask.unobserveField("response")
+    data = parseJSON(obj.getData())
 
-  if data <> invalid
-    if data.files <> invalid
-      m.files = data.files
-      configureFileList()
-    else
-      showErrorDialog(data)
+    if data <> invalid
+        if data.files <> invalid
+            m.files = data.files
+            configureFileList()
+        else
+            showErrorDialog(data)
+        end if
     end if
-  end if
 
-  hideLoading()
+    hideLoading()
 end sub
 
 ''' Events
 sub onFileSelected(obj)
-  file = m.searchFileList.content.getChild(obj.getData()).file
+    file = m.searchFileList.content.getChild(obj.getData()).file
 
-  if isFileSupported(file)
-    setSearchHistory(m.keyboard.text)
-    navigateToFile(file)
-  else
-    showFileNotSupportedDialog(onFileNotSupportedDialogClosed)
-  end if
+    if isFileSupported(file)
+        setSearchHistory(m.keyboard.text)
+        navigateToFile(file)
+    else
+        showFileNotSupportedDialog(onFileNotSupportedDialogClosed)
+    end if
 end sub
 
 sub onHistoryItemSelected(obj)
-  m.keyboard.text = m.searchHistory.content.getChild(obj.getData()).title
-  updateSearchHistoryButtons(m.keyboard.text)
-  m.searchFileList.setFocus(true)
+    m.keyboard.text = m.searchHistory.content.getChild(obj.getData()).title
+    updateSearchHistoryButtons(m.keyboard.text)
+    m.searchFileList.setFocus(true)
 end sub
 
 sub onFileNotSupportedDialogClosed()
-  m.searchFileList.setFocus(true)
+    m.searchFileList.setFocus(true)
 end sub
 
 ''' UI
 sub showLoading()
-  m.loading.visible = "true"
+    m.loading.visible = "true"
 end sub
 
 sub hideLoading()
-  m.loading.visible = "false"
+    m.loading.visible = "false"
 end sub
 
 sub configureFileList()
-  content = createObject("roSGNode", "ContentNode")
+    content = createObject("roSGNode", "ContentNode")
 
-  for each file in m.files
-    listItemData = content.createChild("FileListItemData")
-    listItemData.file = file
-  end for
+    for each file in m.files
+        listItemData = content.createChild("FileListItemData")
+        listItemData.file = file
+    end for
 
-  m.searchFileList.visible = m.files.Count() > 0
-  m.searchFileList.content = content
+    m.searchFileList.visible = m.files.Count() > 0
+    m.searchFileList.content = content
 end sub
 
 ''' Error Dialog
 sub showErrorDialog(data)
-  m.errorDialog = createObject("roSGNode", "ErrorDialog")
-  m.errorDialog .error = data
-  m.errorDialog .observeField("wasClosed", "onErrorDialogClosed")
-  m.top.showDialog = m.errorDialog
+    m.errorDialog = createObject("roSGNode", "ErrorDialog")
+    m.errorDialog.error = data
+    m.errorDialog.observeField("wasClosed", "onErrorDialogClosed")
+    m.top.showDialog = m.errorDialog
 end sub
 
 sub onErrorDialogClosed()
-  m.errorDialog.unobserveField("wasClosed")
+    m.errorDialog.unobserveField("wasClosed")
 end sub
 
 ''' API
 sub fetchSearchHistory()
-  m.fetchSearchHistory.observeField("response", "onFetchSearchHistory")
-  m.fetchSearchHistory.url = "/config/search_history"
-  m.fetchSearchHistory.method = "GET"
-  m.fetchSearchHistory.control = "RUN"
+    m.fetchSearchHistory.observeField("response", "onFetchSearchHistory")
+    m.fetchSearchHistory.url = "/config/search_history"
+    m.fetchSearchHistory.method = "GET"
+    m.fetchSearchHistory.control = "RUN"
 end sub
 
 sub putSearchHistory(historyItems)
-  if historyItems = invalid
-    historyItems = []
-  end if
-  m.putSearchHistory.observeField("response", "onPutSearchHistory")
-  m.putSearchHistory.url = "/config/search_history"
-  m.putSearchHistory.body = { value: historyItems }
-  m.putSearchHistory.method = "PUT"
-  m.putSearchHistory.control = "RUN"
+    if historyItems = invalid
+        historyItems = []
+    end if
+    m.putSearchHistory.observeField("response", "onPutSearchHistory")
+    m.putSearchHistory.url = "/config/search_history"
+    m.putSearchHistory.body = { value: historyItems }
+    m.putSearchHistory.method = "PUT"
+    m.putSearchHistory.control = "RUN"
 end sub
 
 sub onPutSearchHistory()
-  m.putSearchHistory.unobserveField("response")
-  ' if there is an error, just skip
-  fetchSearchHistory()
+    m.putSearchHistory.unobserveField("response")
+    ' if there is an error, just skip
+    fetchSearchHistory()
 end sub
 
 sub onFetchSearchHistory(obj)
-  m.fetchSearchHistory.unobserveField("response")
-  data = parseJSON(obj.getData())
+    m.fetchSearchHistory.unobserveField("response")
+    data = parseJSON(obj.getData())
 
-  if data <> invalid
-    if data.value <> invalid
-      m.searchHistoryItems = data.value
-      updateSearchHistoryButtons(m.keyboard.text)
-    else if data.status_code = 404 or data.status = "OK"
-      putSearchHistory(invalid)
+    if data <> invalid
+        if data.value <> invalid
+            m.searchHistoryItems = data.value
+            updateSearchHistoryButtons(m.keyboard.text)
+        else if data.status_code = 404 or data.status = "OK"
+            putSearchHistory(invalid)
+        end if
     end if
-  end if
 end sub
 
 function onKeyEvent(key, press)
-  if m.top.visible and press
-    if key = "back"
-      m.keyboard.text = ""
-      m.top.navigateBack = "true"
-      return true
-    else if key = "left"
-      if m.searchHistory.isInFocusChain()
-        m.keyboard.setFocus(true)
-        return true
-      else if m.searchFileList.isInFocusChain()
-        m.keyboard.setFocus(true)
-        return true
-      end if
-      return false
-    else if key = "right"
-      if m.keyboard.isInFocusChain()
-        if m.searchHistory.visible
-          m.searchHistory.setFocus(true)
-          return true
-        else if m.searchFileList.visible
-          m.searchFileList.setFocus(true)
-          return true
+    if m.top.visible and press
+        if key = "back"
+            m.keyboard.text = ""
+            m.top.navigateBack = "true"
+            return true
+        else if key = "left"
+            if m.searchHistory.isInFocusChain()
+                m.keyboard.setFocus(true)
+                return true
+            else if m.searchFileList.isInFocusChain()
+                m.keyboard.setFocus(true)
+                return true
+            end if
+            return false
+        else if key = "right"
+            if m.keyboard.isInFocusChain()
+                if m.searchHistory.visible
+                    m.searchHistory.setFocus(true)
+                    return true
+                else if m.searchFileList.visible
+                    m.searchFileList.setFocus(true)
+                    return true
+                end if
+            end if
+            return false
         end if
-      end if
-      return false
+        return false
     end if
-    return false
-  end if
 
-  return false
+    return false
 end function

--- a/components/screens/Settings/Settings.brs
+++ b/components/screens/Settings/Settings.brs
@@ -1,112 +1,112 @@
 function init()
-  m.storage = CreateObject("roRegistrySection", "userConfig")
+    m.storage = CreateObject("roRegistrySection", "userConfig")
 
-  m.top.observeField("visible", "onVisibleChange")
-  m.version = m.top.findNode("version")
-  m.version.text = m.version.text + createObject("roAppInfo").GetVersion()
+    m.top.observeField("visible", "onVisibleChange")
+    m.version = m.top.findNode("version")
+    m.version.text = m.version.text + createObject("roAppInfo").GetVersion()
 
-  m.list = m.top.findNode("settingsList")
-  m.list.observeField("itemSelected", "onListItemSelected")
+    m.list = m.top.findNode("settingsList")
+    m.list.observeField("itemSelected", "onListItemSelected")
 
-  m.items = {
-    show_only_media_files: {
-      title: "Only Show Media Files",
-      iconName: "align-left-1",
-    },
-    show_history: {
-      title: "Keep populating the history page with your activities",
-      iconName: "history-1",
-    },
-    logout: {
-      title: "Log out",
-      iconName: "logout"
+    m.items = {
+        show_only_media_files: {
+            title: "Only Show Media Files",
+            iconName: "align-left-1",
+        },
+        show_history: {
+            title: "Keep populating the history page with your activities",
+            iconName: "history-1",
+        },
+        logout: {
+            title: "Log out",
+            iconName: "logout"
+        }
     }
-  }
-  m.itemsOrder = ["show_only_media_files", "show_history", "logout"]
+    m.itemsOrder = ["show_only_media_files", "show_history", "logout"]
 
-  renderList()
+    renderList()
 end function
 
 sub onVisibleChange()
-  if m.top.visible
-    m.list.setFocus(true)
-    updateShowOnlyMediaValue()
-    updateShowHistory()
-  end if
+    if m.top.visible
+        m.list.setFocus(true)
+        updateShowOnlyMediaValue()
+        updateShowHistory()
+    end if
 end sub
 
 sub renderList()
-  content = createObject("roSGNode", "ContentNode")
+    content = createObject("roSGNode", "ContentNode")
 
-  for i = 0 to m.items.count() - 1
-    key = m.itemsOrder[i]
-    item = m.items[key]
-    listItemData = content.createChild("ListItemData")
-    listItemData.key = key
-    listItemData.title = item.title
-    listItemData.iconName = item.iconName
-    if item.description <> invalid
-      listItemData.description = item.description
-    end if
-    item.node = listItemData
-  end for
+    for i = 0 to m.items.count() - 1
+        key = m.itemsOrder[i]
+        item = m.items[key]
+        listItemData = content.createChild("ListItemData")
+        listItemData.key = key
+        listItemData.title = item.title
+        listItemData.iconName = item.iconName
+        if item.description <> invalid
+            listItemData.description = item.description
+        end if
+        item.node = listItemData
+    end for
 
-  m.list.content = content
+    m.list.content = content
 end sub
 
 sub onListItemSelected(obj)
-  key = m.list.content.getChild(obj.getData()).key
+    key = m.list.content.getChild(obj.getData()).key
 
-  if key = "logout"
-    storage = CreateObject("roRegistrySection", "userConfig")
-    storage.Delete("token")
-    storage.Flush()
-    m.top.navigate = {
-      id: "authScreen"
-      params: {}
-    }
-  else if key = "show_only_media_files"
-    setShowOnlyMedia()
-  else if key = "show_history"
-    updateSetting("history_enabled", (not m.global.user.settings.history_enabled), onUpdateSetting)
-  end if
+    if key = "logout"
+        storage = CreateObject("roRegistrySection", "userConfig")
+        storage.Delete("token")
+        storage.Flush()
+        m.top.navigate = {
+            id: "authScreen"
+            params: {}
+        }
+    else if key = "show_only_media_files"
+        setShowOnlyMedia()
+    else if key = "show_history"
+        updateSetting("history_enabled", (not m.global.user.settings.history_enabled), onUpdateSetting)
+    end if
 end sub
 
 sub onUpdateSetting()
-  updateShowHistory()
+    updateShowHistory()
 end sub
 
 sub updateShowHistory()
-  m.showHistory = m.items.show_history.node
-  if m.global.user.settings.history_enabled
-    m.showHistory.description = "Enabled"
-  else
-    m.showHistory.description = "Disabled"
-  end if
+    m.showHistory = m.items.show_history.node
+    if m.global.user.settings.history_enabled
+        m.showHistory.description = "Enabled"
+    else
+        m.showHistory.description = "Disabled"
+    end if
 end sub
 
 sub setShowOnlyMedia()
-  newValue = not toBool(m.storage.read("show_only_media_files"))
-  m.storage.write("show_only_media_files", newValue.toStr())
-  m.storage.flush()
+    newValue = not toBool(m.storage.read("show_only_media_files"))
+    m.storage.write("show_only_media_files", newValue.toStr())
+    m.storage.flush()
 
-  updateShowOnlyMediaValue()
+    updateShowOnlyMediaValue()
 end sub
 
 sub updateShowOnlyMediaValue()
-  m.showOnlyMediaListItem = m.items.show_only_media_files.node
-  if toBool(m.storage.read("show_only_media_files"))
-    m.showOnlyMediaListItem.description = "Enabled"
-  else
-    m.showOnlyMediaListItem.description = "Disabled"
-  end if
+    m.showOnlyMediaListItem = m.items.show_only_media_files.node
+    if toBool(m.storage.read("show_only_media_files"))
+        m.showOnlyMediaListItem.description = "Enabled"
+    else
+        m.showOnlyMediaListItem.description = "Disabled"
+    end if
 end sub
 
 function onKeyEvent(key, press)
-  if m.top.visible and key = "back" and press
-    m.top.navigateBack = "true"
-    return true
-  end if
+    if m.top.visible and key = "back" and press
+        m.top.navigateBack = "true"
+        return true
+    end if
 
-  return false
+    return false
 end function

--- a/components/screens/Settings/Settings.brs
+++ b/components/screens/Settings/Settings.brs
@@ -68,7 +68,7 @@ sub onListItemSelected(obj)
   else if key = "show_only_media_files"
     setShowOnlyMedia()
   else if key = "show_history"
-    updateSetting("history_enabled", (not m.global.user.settings.history_enabled))
+    updateSetting("history_enabled", (not m.global.user.settings.history_enabled), onUpdateSetting)
   end if
 end sub
 

--- a/components/screens/Video/Video.brs
+++ b/components/screens/Video/Video.brs
@@ -1,246 +1,247 @@
 function init()
-  m.top.observeField("visible", "onVisibleChange")
+    m.top.observeField("visible", "onVisibleChange")
 
-  m.file = {}
-  m.subtitles = []
+    m.file = {}
+    m.subtitles = []
 
-  m.playButton = m.top.findNode("button-play")
-  m.subtitleList = m.top.findNode("subtitleList")
-  m.subtitleList.observeField("itemSelected", "onSubtitleSelected")
+    m.playButton = m.top.findNode("button-play")
+    m.subtitleList = m.top.findNode("subtitleList")
+    m.subtitleList.observeField("itemSelected", "onSubtitleSelected")
 
-  m.fetchFileTask = createObject("roSGNode", "HttpTask")
-  m.fetchSubtitlesTask = createObject("roSGNode", "HttpTask")
+    m.fetchFileTask = createObject("roSGNode", "HttpTask")
+    m.fetchSubtitlesTask = createObject("roSGNode", "HttpTask")
 end function
 
 sub onVisibleChange()
-  if m.top.visible
-    onMount()
-  else
-    cancelHttpTasks()
-  end if
+    if m.top.visible
+        onMount()
+    else
+        cancelHttpTasks()
+    end if
 end sub
 
 sub onMount()
-  setTitle(m.top.params.fileName)
+    setTitle(m.top.params.fileName)
 
-  if m.file.id <> m.top.params.fileId
-    hideContent()
-    showLoading()
-    fetchFile(m.top.params.fileId)
-  else
-    focusPlayButton()
-  end if
+    if m.file.id <> m.top.params.fileId
+        hideContent()
+        showLoading()
+        fetchFile(m.top.params.fileId)
+    else
+        focusPlayButton()
+    end if
 end sub
 
 sub cancelHttpTasks()
-  m.fetchFileTask.unobserveField("response")
-  m.fetchSubtitlesTask.unobserveField("response")
+    m.fetchFileTask.unobserveField("response")
+    m.fetchSubtitlesTask.unobserveField("response")
 end sub
 
 ''' API
 sub fetchFile(fileId)
-  m.fetchFileTask.observeField("response", "onFetchFileResponse")
-  m.fetchFileTask.url = ("/files/list?parent_id=" + fileId.toStr() + "&mp4_status_parent=1&stream_url_parent=1&mp4_stream_url_parent=1&video_metadata_parent=1")
-  m.fetchFileTask.method = "GET"
-  m.fetchFileTask.control = "RUN"
+    m.fetchFileTask.observeField("response", "onFetchFileResponse")
+    m.fetchFileTask.url = ("/files/list?parent_id=" + fileId.toStr() + "&mp4_status_parent=1&stream_url_parent=1&mp4_stream_url_parent=1&video_metadata_parent=1")
+    m.fetchFileTask.method = "GET"
+    m.fetchFileTask.control = "RUN"
 end sub
 
 sub onFetchFileResponse(obj)
-  m.fetchFileTask.unobserveField("response")
-  data = parseJSON(obj.getData())
+    m.fetchFileTask.unobserveField("response")
+    data = parseJSON(obj.getData())
 
-  if data <> invalid and data.parent <> invalid
-    m.file = data.parent
-    fetchSubtitles(m.top.params.fileId)
-  else
-    showFetchFileErrorDialog(data)
-  end if
+    if data <> invalid and data.parent <> invalid
+        m.file = data.parent
+        setTitle(m.file.name)
+        fetchSubtitles(m.top.params.fileId)
+    else
+        showFetchFileErrorDialog(data)
+    end if
 end sub
 
 sub fetchSubtitles(fileId)
-  m.fetchSubtitlesTask.observeField("response", "onFetchSubtitlesResponse")
-  m.fetchSubtitlesTask.url = ("/files/" + fileId.toStr() + "/subtitles")
-  m.fetchSubtitlesTask.method = "GET"
-  m.fetchSubtitlesTask.control = "RUN"
+    m.fetchSubtitlesTask.observeField("response", "onFetchSubtitlesResponse")
+    m.fetchSubtitlesTask.url = ("/files/" + fileId.toStr() + "/subtitles")
+    m.fetchSubtitlesTask.method = "GET"
+    m.fetchSubtitlesTask.control = "RUN"
 end sub
 
 sub onFetchSubtitlesResponse(obj)
-  m.fetchSubtitlesTask.unobserveField("response")
-  data = parseJSON(obj.getData())
+    m.fetchSubtitlesTask.unobserveField("response")
+    data = parseJSON(obj.getData())
 
-  if data <> invalid and data.subtitles <> invalid
-    m.subtitles = data.subtitles
-  end if
+    if data <> invalid and data.subtitles <> invalid
+        m.subtitles = data.subtitles
+    end if
 
-  hideLoading()
-  showContent()
-  focusPlayButton()
+    hideLoading()
+    showContent()
+    focusPlayButton()
 end sub
 
 ''' UI
 sub setTitle(title)
-  m.top.findNode("overhang").title = title
+    m.top.findNode("overhang").title = title
 end sub
 
 sub configurePlayButtonImage()
-  if m.playButton.hasFocus()
-    if m.file.need_convert
-      m.playButton.uri = "pkg:/images/ConvertButtonFocused.png"
-      m.playButton.width = "430"
+    if m.playButton.hasFocus()
+        if m.file.need_convert
+            m.playButton.uri = "pkg:/images/ConvertButtonFocused.png"
+            m.playButton.width = "430"
+        else
+            m.playButton.uri = "pkg:/images/PlayButtonFocused.png"
+            m.playButton.width = "312"
+        end if
     else
-      m.playButton.uri = "pkg:/images/PlayButtonFocused.png"
-      m.playButton.width = "312"
+        if m.file.need_convert
+            m.playButton.uri = "pkg:/images/ConvertButtonUnfocused.png"
+            m.playButton.width = "430"
+        else
+            m.playButton.uri = "pkg:/images/PlayButtonUnfocused.png"
+            m.playButton.width = "312"
+        end if
     end if
-  else
-    if m.file.need_convert
-      m.playButton.uri = "pkg:/images/ConvertButtonUnfocused.png"
-      m.playButton.width = "430"
-    else
-      m.playButton.uri = "pkg:/images/PlayButtonUnfocused.png"
-      m.playButton.width = "312"
-    end if
-  end if
 end sub
 
 sub showLoading()
-  m.top.findNode("loading").visible = "true"
+    m.top.findNode("loading").visible = "true"
 end sub
 
 sub hideLoading()
-  m.top.findNode("loading").visible = "false"
+    m.top.findNode("loading").visible = "false"
 end sub
 
 sub showContent()
-  m.top.findNode("content").visible = "true"
-  setPoster()
-  setSubtitles()
+    m.top.findNode("content").visible = "true"
+    setPoster()
+    setSubtitles()
 end sub
 
 sub hideContent()
-  m.top.findNode("content").visible = "false"
+    m.top.findNode("content").visible = "false"
 end sub
 
 sub setPoster()
-  m.top.findNode("poster").uri = m.file.screenshot
+    m.top.findNode("poster").uri = m.file.screenshot
 end sub
 
 sub setSubtitles()
-  content = createObject("roSGNode", "ContentNode")
+    content = createObject("roSGNode", "ContentNode")
 
-  noSelectionItem = content.createChild("ContentNode")
-  noSelectionItem.title = "Don’t load any subtitles"
+    noSelectionItem = content.createChild("ContentNode")
+    noSelectionItem.title = "Don’t load any subtitles"
 
-  for each subtitle in m.subtitles
-    listItemData = content.createChild("ContentNode")
-    listItemData.title = subtitle.language + " — " + subtitle.name
-    listItemData.title = listItemData.title.replace("Undetermined", "Custom")
-  end for
+    for each subtitle in m.subtitles
+        listItemData = content.createChild("ContentNode")
+        listItemData.title = subtitle.language + " — " + subtitle.name
+        listItemData.title = listItemData.title.replace("Undetermined", "Custom")
+    end for
 
-  m.subtitleList.checkedItem = 0
-  if m.subtitles.count() > 0
-    m.subtitleList.checkedItem = 1
-  end if
-  
-  m.subtitleList.visible = "true"
-  m.subtitleList.content = content
+    m.subtitleList.checkedItem = 0
+    if m.subtitles.count() > 0
+        m.subtitleList.checkedItem = 1
+    end if
+
+    m.subtitleList.visible = "true"
+    m.subtitleList.content = content
 end sub
 
 sub focusPlayButton()
-  m.playButton.setFocus(true)
-  configurePlayButtonImage()
+    m.playButton.setFocus(true)
+    configurePlayButtonImage()
 end sub
 
 sub unfocusPlaybutton()
-  m.playButton.setFocus(false)
-  configurePlayButtonImage()
+    m.playButton.setFocus(false)
+    configurePlayButtonImage()
 end sub
 
 ''' Error Dialog
 sub showFetchFileErrorDialog(data)
-  m.fetchFileErrorDialog = createObject("roSGNode", "ErrorDialog")
-  m.fetchFileErrorDialog.error = data
-  m.fetchFileErrorDialog.observeField("wasClosed", "onFetchFileErrorDialogClosed")
-  m.top.showDialog = m.fetchFileErrorDialog
+    m.fetchFileErrorDialog = createObject("roSGNode", "ErrorDialog")
+    m.fetchFileErrorDialog.error = data
+    m.fetchFileErrorDialog.observeField("wasClosed", "onFetchFileErrorDialogClosed")
+    m.top.showDialog = m.fetchFileErrorDialog
 end sub
 
 sub onFetchFileErrorDialogClosed()
-  m.fetchFileErrorDialog.unobserveField("wasClosed")
-  m.top.navigateBack = "true"
+    m.fetchFileErrorDialog.unobserveField("wasClosed")
+    m.top.navigateBack = "true"
 end sub
 
 ''' Video Conversion Dialog
 sub showVideoConversionDialog()
-  m.videoConversionDialog = createObject("roSGNode", "VideoConversionDialog")
-  m.videoConversionDialog.fileId = m.top.params.fileId
-  m.videoConversionDialog.observeField("completed", "onVideoConversionCompleted")
-  m.videoConversionDialog.observeField("wasClosed", "onVideoConversionDialogClosed")
-  m.top.showDialog = m.videoConversionDialog
+    m.videoConversionDialog = createObject("roSGNode", "VideoConversionDialog")
+    m.videoConversionDialog.fileId = m.top.params.fileId
+    m.videoConversionDialog.observeField("completed", "onVideoConversionCompleted")
+    m.videoConversionDialog.observeField("wasClosed", "onVideoConversionDialogClosed")
+    m.top.showDialog = m.videoConversionDialog
 end sub
 
 sub onVideoConversionDialogClosed()
-  focusPlayButton()
+    focusPlayButton()
 end sub
 
 sub onVideoConversionCompleted()
-  m.file = m.videoConversionDialog.convertedFile
-  onPlay()
+    m.file = m.videoConversionDialog.convertedFile
+    onPlay()
 end sub
 
 ''' Events
 sub onSubtitleSelected()
-  focusPlayButton()
-  onPlay()
+    focusPlayButton()
+    onPlay()
 end sub
 
 sub onPlay()
-  if m.file.need_convert
-    showVideoConversionDialog()
-    return
-  end if
+    if m.file.need_convert
+        showVideoConversionDialog()
+        return
+    end if
 
-  if m.subtitleList.checkedItem = 0
-    selectedSubtitle = {}
-  else if m.subtitles[m.subtitleList.checkedItem - 1] <> invalid
-    selectedSubtitle = m.subtitles[m.subtitleList.checkedItem - 1]
-  end if
+    if m.subtitleList.checkedItem = 0
+        selectedSubtitle = {}
+    else if m.subtitles[m.subtitleList.checkedItem - 1] <> invalid
+        selectedSubtitle = m.subtitles[m.subtitleList.checkedItem - 1]
+    end if
 
-  m.top.navigate = {
-    id: "videoPlayerScreen",
-    params: {
-      file: m.file,
-      subtitle: selectedSubtitle,
+    m.top.navigate = {
+        id: "videoPlayerScreen",
+        params: {
+            file: m.file,
+            subtitle: selectedSubtitle,
+        }
     }
-  }
 end sub
 
 function onKeyEvent(key, press)
-  if m.top.visible and press
-    if key = "back"
-      m.top.navigateBack = "true"
-      return true
+    if m.top.visible and press
+        if key = "back"
+            m.top.navigateBack = "true"
+            return true
+        end if
+
+        if m.playButton.hasFocus()
+            if key = "OK"
+                onPlay()
+                return true
+            end if
+
+            if key = "down"
+                unfocusPlaybutton()
+                m.subtitleList.setFocus(true)
+                return true
+            end if
+        end if
+
+        if m.subtitleList.hasFocus()
+            if key = "up"
+                m.subtitleList.setFocus(false)
+                focusPlayButton()
+                return true
+            end if
+        end if
     end if
 
-    if m.playButton.hasFocus()
-      if key = "OK"
-        onPlay()
-        return true
-      end if
-
-      if key = "down"
-        unfocusPlaybutton()
-        m.subtitleList.setFocus(true)
-        return true
-      end if
-    end if
-
-    if m.subtitleList.hasFocus()
-      if key = "up"
-        m.subtitleList.setFocus(false)
-        focusPlayButton()
-        return true
-      end if
-    end if
-  end if
-
-  return false
+    return false
 end function

--- a/components/screens/VideoPlayer/VideoPlayer.brs
+++ b/components/screens/VideoPlayer/VideoPlayer.brs
@@ -1,204 +1,204 @@
 function init()
-  m.top.observeField("visible", "onVisibleChange")
-  m.video = m.top.findNode("video")
-  m.video.retrievingBar.filledBarBlendColor = "0xFFCF00FF"
-  m.video.trickPlayBar.filledBarBlendColor = "0xFFCF00FF"
-  m.video.trickPlayBar.currentTimeMarkerBlendColor = "0xFFFFFFFF"
-  m.video.trickPlayBar.thumbBlendColor = "0xFFFFFFFF"
-  m.video.bufferingBar.filledBarBlendColor = "0xFFCF00FF"
+    m.top.observeField("visible", "onVisibleChange")
+    m.video = m.top.findNode("video")
+    m.video.retrievingBar.filledBarBlendColor = "0xFFCF00FF"
+    m.video.trickPlayBar.filledBarBlendColor = "0xFFCF00FF"
+    m.video.trickPlayBar.currentTimeMarkerBlendColor = "0xFFFFFFFF"
+    m.video.trickPlayBar.thumbBlendColor = "0xFFFFFFFF"
+    m.video.bufferingBar.filledBarBlendColor = "0xFFCF00FF"
 end function
 
 sub onVisibleChange()
-  if m.top.visible
-    m.video.notificationInterval = 10
-    m.video.observeField("state", "onPlayerStateChanged")
-    m.video.observeField("position", "onPlayerPositionChanged")
-    setupPlayer()
-  else
-    m.video.unobserveField("state")
-    m.video.unobserveField("position")
-  end if
+    if m.top.visible
+        m.video.notificationInterval = 10
+        m.video.observeField("state", "onPlayerStateChanged")
+        m.video.observeField("position", "onPlayerPositionChanged")
+        setupPlayer()
+    else
+        m.video.unobserveField("state")
+        m.video.unobserveField("position")
+    end if
 end sub
 
 sub setupPlayer()
-  file = m.top.params.file
-  subtitle = m.top.params.subtitle
-  videoContent = createObject("RoSGNode", "ContentNode")
+    file = m.top.params.file
+    subtitle = m.top.params.subtitle
+    videoContent = createObject("RoSGNode", "ContentNode")
 
-  if file.is_mp4_available = true
-    videoContent.url = file.mp4_stream_url
-  else
-    videoContent.url = file.stream_url
-  end if
+    if file.is_mp4_available = true
+        videoContent.url = file.mp4_stream_url
+    else
+        videoContent.url = file.stream_url
+    end if
 
-  videoContent.title = file.name
-  videoContent.streamformat = "mp4"
+    videoContent.title = file.name
+    videoContent.streamformat = "mp4"
 
-  if subtitle <> invalid and subtitle.url <> invalid and subtitle.url <> ""
-    subtitleTrack = createSubtitleTrack(subtitle)
-    videoContent.subtitletracks = [subtitleTrack]
-    videoContent.subtitleconfig = {
-      TrackName: subtitleTrack.TrackName
-    }
-  end if
+    if subtitle <> invalid and subtitle.url <> invalid and subtitle.url <> ""
+        subtitleTrack = createSubtitleTrack(subtitle)
+        videoContent.subtitletracks = [subtitleTrack]
+        videoContent.subtitleconfig = {
+            TrackName: subtitleTrack.TrackName
+        }
+    end if
 
-  m.video.content = videoContent
+    m.video.content = videoContent
 
-  fetchStartFrom()
+    fetchStartFrom()
 end sub
 
 function createSubtitleTrack(subtitle)
-  return {
-    Language: getSubtitleLanguageCode(subtitle),
-    TrackName: subtitle.url,
-    Description: subtitle.name
-  }
+    return {
+        Language: getSubtitleLanguageCode(subtitle),
+        TrackName: subtitle.url,
+        Description: subtitle.name
+    }
 end function
 
-function getSubtitleLanguageCode(subtitle) as String
-  if subtitle.language_code <> invalid and subtitle.language_code <> ""
-    return subtitle.language_code
-  end if
+function getSubtitleLanguageCode(subtitle) as string
+    if subtitle.language_code <> invalid and subtitle.language_code <> ""
+        return subtitle.language_code
+    end if
 
-  if subtitle.language <> invalid and subtitle.language <> ""
-    return subtitle.language
-  end if
+    if subtitle.language <> invalid and subtitle.language <> ""
+        return subtitle.language
+    end if
 
-  return "und"
+    return "und"
 end function
 
 sub fetchStartFrom()
-  m.fetchStartFromTask = createObject("roSGNode", "HttpTask")
-  m.fetchStartFromTask.observeField("response", "onFetchStartFromResponse")
-  m.fetchStartFromTask.url = ("/files/" + m.top.params.file.id.toStr() + "/start-from")
-  m.fetchStartFromTask.method = "GET"
-  m.fetchStartFromTask.control = "RUN"
+    m.fetchStartFromTask = createObject("roSGNode", "HttpTask")
+    m.fetchStartFromTask.observeField("response", "onFetchStartFromResponse")
+    m.fetchStartFromTask.url = ("/files/" + m.top.params.file.id.toStr() + "/start-from")
+    m.fetchStartFromTask.method = "GET"
+    m.fetchStartFromTask.control = "RUN"
 end sub
 
 sub onFetchStartFromResponse(obj)
-  m.fetchStartFromTask.unobserveField("response")
-  data = parseJSON(obj.getData())
+    m.fetchStartFromTask.unobserveField("response")
+    data = parseJSON(obj.getData())
 
-  if data <> invalid and data.start_from <> invalid and data.start_from > 0
-    m.fetchedStartFrom = data.start_from
-    showChooseStartFromDialog()
-  else
-    startPlayback(0)
-  end if
+    if data <> invalid and data.start_from <> invalid and data.start_from > 0
+        m.fetchedStartFrom = data.start_from
+        showChooseStartFromDialog()
+    else
+        startPlayback(0)
+    end if
 end sub
 
 sub startPlayback(time)
-  m.video.control = "play"
-  m.video.seek = time
-  m.video.setFocus(true)
+    m.video.control = "play"
+    m.video.seek = time
+    m.video.setFocus(true)
 end sub
 
 sub showChooseStartFromDialog()
-  m.chooseStartFromDialog = createObject("roSGNode", "Dialog")
-  m.chooseStartFromDialog.title = "Where would you like to start?"
-  m.chooseStartFromDialog.message = "Last saved timestamp for this video is " + getDurationString(m.fetchedStartFrom) + " of " + getDurationString(m.top.params.file.video_metadata.duration)
-  m.chooseStartFromDialog.buttons = [
-    "Continue watching",
-    "Start from the beginning"
-  ]
+    m.chooseStartFromDialog = createObject("roSGNode", "Dialog")
+    m.chooseStartFromDialog.title = "Where would you like to start?"
+    m.chooseStartFromDialog.message = "Last saved timestamp for this video is " + getDurationString(m.fetchedStartFrom) + " of " + getDurationString(m.top.params.file.video_metadata.duration)
+    m.chooseStartFromDialog.buttons = [
+        "Continue watching",
+        "Start from the beginning"
+    ]
 
-  m.chooseStartFromDialog.observeField("buttonSelected", "onChooseStartFromDialogButtonSelected")
-  m.chooseStartFromDialog.observeField("wasClosed", "onChooseStartFromDialogClosed")
-  m.top.showDialog = m.chooseStartFromDialog
+    m.chooseStartFromDialog.observeField("buttonSelected", "onChooseStartFromDialogButtonSelected")
+    m.chooseStartFromDialog.observeField("wasClosed", "onChooseStartFromDialogClosed")
+    m.top.showDialog = m.chooseStartFromDialog
 end sub
 
 sub onChooseStartFromDialogButtonSelected(obj)
-  m.chooseStartFromDialog.unobserveField("buttonSelected")
-  m.chooseStartFromDialog.close = "true"
+    m.chooseStartFromDialog.unobserveField("buttonSelected")
+    m.chooseStartFromDialog.close = "true"
 
-  if obj.getData() = 0
-    startPlayback(m.fetchedStartFrom)
-  else
-    startPlayback(0)
-  end if
+    if obj.getData() = 0
+        startPlayback(m.fetchedStartFrom)
+    else
+        startPlayback(0)
+    end if
 end sub
 
 sub onChooseStartFromDialogClosed()
-  m.chooseStartFromDialog.unobserveField("wasClosed")
+    m.chooseStartFromDialog.unobserveField("wasClosed")
 
-  if m.video.control <> "play"
-    startPlayback(0)
-  end if
+    if m.video.control <> "play"
+        startPlayback(0)
+    end if
 end sub
 
 sub onPlayerStateChanged(obj)
-  state = obj.getData()
+    state = obj.getData()
 
-  if state = "error"
-    onError()
-	else if state = "finished"
-    onGoBack()
-	end if
+    if state = "error"
+        onError()
+    else if state = "finished"
+        onGoBack()
+    end if
 end sub
 
 sub onError()
-  m.errorDialog = createObject("roSGNode", "Dialog")
-  m.errorDialog.title = "Video Error"
-  m.errorDialog.message = m.video.errorMsg + chr(10) + "Code: " + m.video.errorCode.toStr()
-  m.errorDialog.observeField("wasClosed", "onErrorDialogClosed")
-  m.top.showDialog = m.errorDialog
+    m.errorDialog = createObject("roSGNode", "Dialog")
+    m.errorDialog.title = "Video Error"
+    m.errorDialog.message = m.video.errorMsg + chr(10) + "Code: " + m.video.errorCode.toStr()
+    m.errorDialog.observeField("wasClosed", "onErrorDialogClosed")
+    m.top.showDialog = m.errorDialog
 end sub
 
 sub onErrorDialogClosed()
-  onGoBack()
+    onGoBack()
 end sub
 
 sub onPlayerPositionChanged(obj)
-  if m.global.user.settings.start_from = true
-    saveVideoTime(obj.getData())
-  end if
+    if m.global.user.settings.start_from = true
+        saveVideoTime(obj.getData())
+    end if
 end sub
 
 sub saveVideoTime(time)
-  if time > 0
-    m.setStartFromTask = createObject("roSGNode", "HttpTask")
-    m.setStartFromTask.url = ("/files/" + m.top.params.file.id.toStr() + "/start-from/set")
-    m.setStartFromTask.method = "POST"
-    m.setStartFromTask.body = { time: time }
-    m.setStartFromTask.control = "RUN"
-  end if
+    if time > 0
+        m.setStartFromTask = createObject("roSGNode", "HttpTask")
+        m.setStartFromTask.url = ("/files/" + m.top.params.file.id.toStr() + "/start-from/set")
+        m.setStartFromTask.method = "POST"
+        m.setStartFromTask.body = { time: time }
+        m.setStartFromTask.control = "RUN"
+    end if
 end sub
 
 sub onGoBack()
-  m.video.control = "stop"
-  m.top.navigateBack = "true"
+    m.video.control = "stop"
+    m.top.navigateBack = "true"
 end sub
 
 function onKeyEvent(key, press)
-  if m.top.visible and press and key = "back"
-    onGoBack()
-    return true
-  end if
+    if m.top.visible and press and key = "back"
+        onGoBack()
+        return true
+    end if
 
-  return false
+    return false
 end function
 
-sub getDurationString(seconds) as String
-	datetime = CreateObject("roDateTime")
-	datetime.FromSeconds(seconds)
+sub getDurationString(seconds) as string
+    datetime = CreateObject("roDateTime")
+    datetime.FromSeconds(seconds)
 
-	hours = datetime.GetHours().ToStr()
-	minutes = datetime.GetMinutes().ToStr()
-	seconds = datetime.GetSeconds().ToStr()
+    hours = datetime.GetHours().ToStr()
+    minutes = datetime.GetMinutes().ToStr()
+    seconds = datetime.GetSeconds().ToStr()
 
-	If Len(hours) = 1 Then
-		hours = "0" + hours
-	End If
-	If Len(minutes) = 1 Then
-		minutes = "0" + minutes
-	End If
-	If Len(seconds) = 1 Then
-		seconds = "0" + seconds
-	End If
+    if Len(hours) = 1 then
+        hours = "0" + hours
+    end if
+    if Len(minutes) = 1 then
+        minutes = "0" + minutes
+    end if
+    if Len(seconds) = 1 then
+        seconds = "0" + seconds
+    end if
 
-	if hours <> "00"
-		return hours + ":" + minutes + ":" + seconds
-	else
-		return minutes + ":" + seconds
-	end if
+    if hours <> "00"
+        return hours + ":" + minutes + ":" + seconds
+    else
+        return minutes + ":" + seconds
+    end if
 end sub

--- a/components/screens/VideoPlayer/VideoPlayer.brs
+++ b/components/screens/VideoPlayer/VideoPlayer.brs
@@ -34,20 +34,38 @@ sub setupPlayer()
   videoContent.title = file.name
   videoContent.streamformat = "mp4"
 
-  if subtitle <> invalid and subtitle.url <> invalid
-    videoContent.subtitletracks = [
-      {
-        Language: subtitle.language,
-        Trackname: subtitle.url,
-        Description: subtitle.name
-      }
-    ]
+  if subtitle <> invalid and subtitle.url <> invalid and subtitle.url <> ""
+    subtitleTrack = createSubtitleTrack(subtitle)
+    videoContent.subtitletracks = [subtitleTrack]
+    videoContent.subtitleconfig = {
+      TrackName: subtitleTrack.TrackName
+    }
   end if
 
   m.video.content = videoContent
 
   fetchStartFrom()
 end sub
+
+function createSubtitleTrack(subtitle)
+  return {
+    Language: getSubtitleLanguageCode(subtitle),
+    TrackName: subtitle.url,
+    Description: subtitle.name
+  }
+end function
+
+function getSubtitleLanguageCode(subtitle) as String
+  if subtitle.language_code <> invalid and subtitle.language_code <> ""
+    return subtitle.language_code
+  end if
+
+  if subtitle.language <> invalid and subtitle.language <> ""
+    return subtitle.language
+  end if
+
+  return "und"
+end function
 
 sub fetchStartFrom()
   m.fetchStartFromTask = createObject("roSGNode", "HttpTask")
@@ -123,7 +141,7 @@ sub onError()
   m.errorDialog.title = "Video Error"
   m.errorDialog.message = m.video.errorMsg + chr(10) + "Code: " + m.video.errorCode.toStr()
   m.errorDialog.observeField("wasClosed", "onErrorDialogClosed")
-  m.top.showDialog = errorDialog
+  m.top.showDialog = m.errorDialog
 end sub
 
 sub onErrorDialogClosed()

--- a/components/shared/DeleteFileDialog/DeleteFileDialog.brs
+++ b/components/shared/DeleteFileDialog/DeleteFileDialog.brs
@@ -1,41 +1,41 @@
 sub init()
-  m.top.buttons = ["Yes, delete file", "Cancel"]
-  m.top.observeField("buttonSelected", "onButtonSelected")
+    m.top.buttons = ["Yes, delete file", "Cancel"]
+    m.top.observeField("buttonSelected", "onButtonSelected")
 end sub
 
 sub onFileChange()
-  m.top.title = "Confirmation"
-  m.top.message = "Are you sure you want to delete " + m.top.file.name + "?"
+    m.top.title = "Confirmation"
+    m.top.message = "Are you sure you want to delete " + m.top.file.name + "?"
 end sub
 
 sub onButtonSelected(obj)
-  if obj.getData() = 0
-    deleteSelectedFile()
-  else
-    m.top.close = "true"
-  end if
+    if obj.getData() = 0
+        deleteSelectedFile()
+    else
+        m.top.close = "true"
+    end if
 end sub
 
 sub deleteSelectedFile()
-  m.top.buttons = []
-  m.top.message = "Deleting..."
+    m.top.buttons = []
+    m.top.message = "Deleting..."
 
-  m.deleteFileTask = createObject("roSGNode", "HttpTask")
-  m.deleteFileTask.observeField("response", "onDeleteFileResponse")
-  m.deleteFileTask.url = "/files/delete"
-  m.deleteFileTask.method = "POST"
-  m.deleteFileTask.body = { file_ids: [m.top.file.id] }
-  m.deleteFileTask.control = "RUN"
+    m.deleteFileTask = createObject("roSGNode", "HttpTask")
+    m.deleteFileTask.observeField("response", "onDeleteFileResponse")
+    m.deleteFileTask.url = "/files/delete"
+    m.deleteFileTask.method = "POST"
+    m.deleteFileTask.body = { file_ids: [m.top.file.id] }
+    m.deleteFileTask.control = "RUN"
 end sub
 
 sub onDeleteFileResponse(obj)
-  m.deleteFileTask.unobserveField("response")
-  data = parseJSON(obj.getData())
+    m.deleteFileTask.unobserveField("response")
+    data = parseJSON(obj.getData())
 
-  if data.status <> invalid and data.status = "OK"
-    m.top.completed = "true"
-    m.top.close = "true"
-  else
-    m.top.message = "An error ocurred, please try again."
-  end if
+    if data.status <> invalid and data.status = "OK"
+        m.top.completed = "true"
+        m.top.close = "true"
+    else
+        m.top.message = "An error ocurred, please try again."
+    end if
 end sub

--- a/components/shared/DeleteFileDialog/DeleteFileDialog.brs
+++ b/components/shared/DeleteFileDialog/DeleteFileDialog.brs
@@ -10,13 +10,13 @@ end sub
 
 sub onButtonSelected(obj)
   if obj.getData() = 0
-    deleteFile()
+    deleteSelectedFile()
   else
     m.top.close = "true"
   end if
 end sub
 
-sub deleteFile()
+sub deleteSelectedFile()
   m.top.buttons = []
   m.top.message = "Deleting..."
 

--- a/components/shared/ErrorDialog/ErrorDialog.brs
+++ b/components/shared/ErrorDialog/ErrorDialog.brs
@@ -1,19 +1,19 @@
 sub init()
-  m.top.title = "Oops, an error occurred"
-  m.top.message = ""
+    m.top.title = "Oops, an error occurred"
+    m.top.message = ""
 end sub
 
 sub onErrorChange(obj)
-  error_type = obj.getData().error_type
-  error_message = obj.getData().error_message
+    error_type = obj.getData().error_type
+    error_message = obj.getData().error_message
 
-  if error_type <> invalid and error_message <> invalid
-    if error_type = "NotFound"
-      m.top.message = "File not found"
+    if error_type <> invalid and error_message <> invalid
+        if error_type = "NotFound"
+            m.top.message = "File not found"
+        else
+            m.top.message = error_message
+        end if
     else
-      m.top.message = error_message
+        m.top.message = "Please restart your device and try again."
     end if
-  else
-    m.top.message = "Please restart your device and try again."
-  end if
 end sub

--- a/components/shared/HttpTask/HttpTask.brs
+++ b/components/shared/HttpTask/HttpTask.brs
@@ -1,69 +1,69 @@
 sub init()
-  m.top.functionname = "request"
-  m.top.response = ""
+    m.top.functionname = "request"
+    m.top.response = ""
 end sub
 
 function request()
-  port = createObject("roMessagePort")
-  m.http = createObject("roUrlTransfer")
-  m.http.RetainBodyOnError(true)
-  m.http.setPort(port)
-  m.http.setCertificatesFile("common:/certs/ca-bundle.crt")
-  m.http.enablehostverification(false)
-  m.http.enablepeerverification(false)
+    port = createObject("roMessagePort")
+    m.http = createObject("roUrlTransfer")
+    m.http.RetainBodyOnError(true)
+    m.http.setPort(port)
+    m.http.setCertificatesFile("common:/certs/ca-bundle.crt")
+    m.http.enablehostverification(false)
+    m.http.enablepeerverification(false)
 
-  ' Inject Token
-  storage = CreateObject("roRegistrySection", "userConfig")
-  if storage.Exists("token")
-    m.http.AddHeader("Authorization", "token " + storage.Read("token"))
-  end if
-
-  m.http.InitClientCertificates()
-
-  ' Set URL
-  m.http.SetUrl(m.global.apiURL + m.top.url)
-
-  ' Set Request Method
-  m.http.SetRequest(m.top.method)
-
-  ' Make Request
-  if m.top.method = "POST" or m.top.method = "PUT"
-    body = ""
-
-    if m.top.body <> invalid
-      m.http.AddHeader("Content-Type", "application/json")
-      body = formatJSON(m.top.body)
+    ' Inject Token
+    storage = CreateObject("roRegistrySection", "userConfig")
+    if storage.Exists("token")
+        m.http.AddHeader("Authorization", "token " + storage.Read("token"))
     end if
 
-    if m.http.AsyncPostFromString(body) Then
-      msg = wait(10000, port) ' I guess this is something like timeout
-      onResponse(msg)
+    m.http.InitClientCertificates()
+
+    ' Set URL
+    m.http.SetUrl(m.global.apiURL + m.top.url)
+
+    ' Set Request Method
+    m.http.SetRequest(m.top.method)
+
+    ' Make Request
+    if m.top.method = "POST" or m.top.method = "PUT"
+        body = ""
+
+        if m.top.body <> invalid
+            m.http.AddHeader("Content-Type", "application/json")
+            body = formatJSON(m.top.body)
+        end if
+
+        if m.http.AsyncPostFromString(body) then
+            msg = wait(10000, port) ' I guess this is something like timeout
+            onResponse(msg)
+        end if
+    else
+        if m.http.AsyncGetToString() then
+            msg = wait(10000, port) ' I guess this is something like timeout
+            onResponse(msg)
+        end if
     end if
-  else
-    if m.http.AsyncGetToString() Then
-      msg = wait(10000, port) ' I guess this is something like timeout
-      onResponse(msg)
-    end if
-  end if
 
 end function
 
 sub onResponse(msg)
-  ' ? "HttpTask Message: "; msg.getstring()
-  ' ? "HttpTask ResponseCode: "; msg.getresponsecode()
+    ' ? "HttpTask Message: "; msg.getstring()
+    ' ? "HttpTask ResponseCode: "; msg.getresponsecode()
 
-  if (type(msg) = "roUrlEvent")
-    if (msg.getresponsecode() > 0 and msg.getresponsecode() < 400)
-      m.top.response = msg.getstring()
-    else
-      ? "HttpTask Failed (Response Code): "; msg.getstring()
-      m.top.response = msg.getstring()
+    if (type(msg) = "roUrlEvent")
+        if (msg.getresponsecode() > 0 and msg.getresponsecode() < 400)
+            m.top.response = msg.getstring()
+        else
+            ? "HttpTask Failed (Response Code): "; msg.getstring()
+            m.top.response = msg.getstring()
+        end if
+    else if (msg = invalid)
+        ? "HttpTask Failed (Response Code): "; msg
+        m.top.response = "{ error_type: 'NETWORK_ERROR', error_message: 'Network Error' }"
     end if
-  else if (msg = invalid)
-    ? "HttpTask Failed (Response Code): "; msg
-    m.top.response = "{ error_type: 'NETWORK_ERROR', error_message: 'Network Error' }"
-  end if
 
-  m.http.asynccancel()
-  m.top.response = ""
+    m.http.asynccancel()
+    m.top.response = ""
 end sub

--- a/components/shared/ListItem/ListItem.brs
+++ b/components/shared/ListItem/ListItem.brs
@@ -1,25 +1,25 @@
 function init()
-  m.icon = m.top.findNode("icon")
-  m.title = m.top.findNode("title")
-  m.description = m.top.findNode("description")
+    m.icon = m.top.findNode("icon")
+    m.title = m.top.findNode("title")
+    m.description = m.top.findNode("description")
 end function
 
 sub itemContentChanged()
-  configureIcon()
-  configureTitle()
-  configureDescription()
+    configureIcon()
+    configureTitle()
+    configureDescription()
 end sub
 
 sub configureIcon()
-  m.icon.uri = "pkg:/images/icons/" + m.top.itemContent.iconName + ".png"
+    m.icon.uri = "pkg:/images/icons/" + m.top.itemContent.iconName + ".png"
 end sub
 
 sub configureTitle()
-  m.title.text = m.top.itemContent.title
+    m.title.text = m.top.itemContent.title
 end sub
 
 sub configureDescription()
-  if m.top.itemContent.description <> invalid
-    m.description.text = m.top.itemContent.description
-  end if
+    if m.top.itemContent.description <> invalid
+        m.description.text = m.top.itemContent.description
+    end if
 end sub

--- a/components/shared/LoadingIndicator/LoadingIndicator.brs
+++ b/components/shared/LoadingIndicator/LoadingIndicator.brs
@@ -1,242 +1,242 @@
 sub init()
-  m.image = m.top.findNode("image")
-  m.image.observeField("loadStatus", "omImageLoadStatusChange")
-  m.text = m.top.findNode("text")
-  m.rotationAnimation = m.top.findNode("rotationAnimation")
-  m.rotationAnimationInterpolator = m.top.findNode("rotationAnimationInterpolator")
-  m.fadeAnimation = m.top.findNode("fadeAnimation")
-  m.loadingIndicatorGroup = m.top.findNode("loadingIndicatorGroup")
-  m.loadingGroup = m.top.findNode("loadingGroup")
-  m.background = m.top.findNode("background")
+    m.image = m.top.findNode("image")
+    m.image.observeField("loadStatus", "omImageLoadStatusChange")
+    m.text = m.top.findNode("text")
+    m.rotationAnimation = m.top.findNode("rotationAnimation")
+    m.rotationAnimationInterpolator = m.top.findNode("rotationAnimationInterpolator")
+    m.fadeAnimation = m.top.findNode("fadeAnimation")
+    m.loadingIndicatorGroup = m.top.findNode("loadingIndicatorGroup")
+    m.loadingGroup = m.top.findNode("loadingGroup")
+    m.background = m.top.findNode("background")
 
-  m.textHeight = 0
-  m.textPadding = 0
+    m.textHeight = 0
+    m.textPadding = 0
 
-  ' image could've been loaded by this time
-  omImageLoadStatusChange()
+    ' image could've been loaded by this time
+    omImageLoadStatusChange()
 
-  startAnimation()
+    startAnimation()
 end sub
 
 
 sub updateLayout()
-  ' check for parent node and set observers
-  if m.top.getParent() <> invalid
-    m.top.getParent().observeField("width", "updateLayout")
-    m.top.getParent().observeField("height", "updateLayout")
-  end if
-  componentWidth = getComponentWidth()
-  componentHeight = getComponentHeight()
-
-  m.text.width = componentWidth - m.textPadding * 2
-  m.background.width = componentWidth
-  m.background.height = componentHeight
-
-  if m.top.centered
-    m.top.translation = [(getParentWidth() - componentWidth) / 2, (getParentHeight() - componentHeight) / 2]
-  end if
-
-  loadingGroupWidth = max(m.image.width, m.text.width)
-
-  loadingGroupHeight = m.image.height + m.textHeight
-
-  ' check whether image and text fit into component, if they don't - downscale image
-  if m.imageAspectRatio <> invalid
-    loadingGroupAspectRatio = loadingGroupWidth / loadingGroupHeight
-    if loadingGroupWidth > componentWidth
-      m.image.width = m.image.width - (loadingGroupWidth - componentWidth)
-      m.image.height = m.image.width / m.imageAspectRatio
-      loadingGroupWidth = max(m.image.width, m.text.width)
-      loadingGroupHeight = loadingGroupWidth / loadingGroupAspectRatio
+    ' check for parent node and set observers
+    if m.top.getParent() <> invalid
+        m.top.getParent().observeField("width", "updateLayout")
+        m.top.getParent().observeField("height", "updateLayout")
     end if
-    if loadingGroupHeight > componentHeight
-      m.image.height = m.image.height - (loadingGroupHeight - componentHeight)
-      m.image.width = m.image.height * m.imageAspectRatio
-      loadingGroupHeight = m.image.height + m.textHeight
-      loadingGroupWidth = loadingGroupHeight * loadingGroupAspectRatio
+    componentWidth = getComponentWidth()
+    componentHeight = getComponentHeight()
+
+    m.text.width = componentWidth - m.textPadding * 2
+    m.background.width = componentWidth
+    m.background.height = componentHeight
+
+    if m.top.centered
+        m.top.translation = [(getParentWidth() - componentWidth) / 2, (getParentHeight() - componentHeight) / 2]
     end if
-  end if
 
-  m.image.scaleRotateCenter = [m.image.width / 2, m.image.height / 2]
+    loadingGroupWidth = max(m.image.width, m.text.width)
 
-  ' position loading group, image and text at the center
-  m.loadingGroup.translation = [(componentWidth - loadingGroupWidth) / 2, (componentHeight - loadingGroupHeight) / 2]
-  m.image.translation = [(loadingGroupWidth - m.image.width) / 2, 0]
-  m.text.translation = [0, m.image.height + m.top.spacing]
+    loadingGroupHeight = m.image.height + m.textHeight
+
+    ' check whether image and text fit into component, if they don't - downscale image
+    if m.imageAspectRatio <> invalid
+        loadingGroupAspectRatio = loadingGroupWidth / loadingGroupHeight
+        if loadingGroupWidth > componentWidth
+            m.image.width = m.image.width - (loadingGroupWidth - componentWidth)
+            m.image.height = m.image.width / m.imageAspectRatio
+            loadingGroupWidth = max(m.image.width, m.text.width)
+            loadingGroupHeight = loadingGroupWidth / loadingGroupAspectRatio
+        end if
+        if loadingGroupHeight > componentHeight
+            m.image.height = m.image.height - (loadingGroupHeight - componentHeight)
+            m.image.width = m.image.height * m.imageAspectRatio
+            loadingGroupHeight = m.image.height + m.textHeight
+            loadingGroupWidth = loadingGroupHeight * loadingGroupAspectRatio
+        end if
+    end if
+
+    m.image.scaleRotateCenter = [m.image.width / 2, m.image.height / 2]
+
+    ' position loading group, image and text at the center
+    m.loadingGroup.translation = [(componentWidth - loadingGroupWidth) / 2, (componentHeight - loadingGroupHeight) / 2]
+    m.image.translation = [(loadingGroupWidth - m.image.width) / 2, 0]
+    m.text.translation = [0, m.image.height + m.top.spacing]
 end sub
 
 
 sub changeRotationDirection()
-  if m.top.clockwise
-    m.rotationAnimationInterpolator.key = [1, 0]
-  else
-    m.rotationAnimationInterpolator.key = [0, 1]
-  end if
+    if m.top.clockwise
+        m.rotationAnimationInterpolator.key = [1, 0]
+    else
+        m.rotationAnimationInterpolator.key = [0, 1]
+    end if
 end sub
 
 
 sub omImageLoadStatusChange()
-  if m.image.loadStatus = "ready"
-    m.imageAspectRatio = m.image.bitmapWidth / m.image.bitmapHeight
+    if m.image.loadStatus = "ready"
+        m.imageAspectRatio = m.image.bitmapWidth / m.image.bitmapHeight
 
-    if m.top.imageWidth > 0 and m.top.imageHeight <= 0
-      m.image.height = m.image.width / m.imageAspectRatio
-    else if m.top.imageHeight > 0 and m.top.imageWidth <= 0
-      m.image.width = m.image.height * m.imageAspectRatio
-    else if m.top.imageHeight <= 0 and m.top.imageWidth <= 0
-      m.image.height = m.image.bitmapHeight
-      m.image.width = m.image.bitmapWidth
+        if m.top.imageWidth > 0 and m.top.imageHeight <= 0
+            m.image.height = m.image.width / m.imageAspectRatio
+        else if m.top.imageHeight > 0 and m.top.imageWidth <= 0
+            m.image.width = m.image.height * m.imageAspectRatio
+        else if m.top.imageHeight <= 0 and m.top.imageWidth <= 0
+            m.image.height = m.image.bitmapHeight
+            m.image.width = m.image.bitmapWidth
+        end if
+        updateLayout()
     end if
-    updateLayout()
-  end if
 end sub
 
 
 sub onImageWidthChange()
-  if m.top.imageWidth > 0
-    m.image.width = m.top.imageWidth
-    if m.top.imageHeight <= 0 and m.imageAspectRatio <> invalid
-      m.image.height = m.image.width / m.imageAspectRatio
+    if m.top.imageWidth > 0
+        m.image.width = m.top.imageWidth
+        if m.top.imageHeight <= 0 and m.imageAspectRatio <> invalid
+            m.image.height = m.image.width / m.imageAspectRatio
+        end if
+        updateLayout()
     end if
-    updateLayout()
-  end if
 end sub
 
 
 sub onImageHeightChange()
-  if m.top.imageHeight > 0
-    m.image.height = m.top.imageHeight
-    if m.top.imageWidth <= 0 and m.imageAspectRatio <> invalid
-      m.image.width = m.image.height * m.imageAspectRatio
+    if m.top.imageHeight > 0
+        m.image.height = m.top.imageHeight
+        if m.top.imageWidth <= 0 and m.imageAspectRatio <> invalid
+            m.image.width = m.image.height * m.imageAspectRatio
+        end if
+        updateLayout()
     end if
-    updateLayout()
-  end if
 end sub
 
 
 sub onTextChange()
-  prevTextHeight = m.textHeight
+    prevTextHeight = m.textHeight
 
-  if m.top.text = ""
-    m.textHeight = 0
-  else
-    m.textHeight = m.text.localBoundingRect().height + m.top.spacing
-  end if
+    if m.top.text = ""
+        m.textHeight = 0
+    else
+        m.textHeight = m.text.localBoundingRect().height + m.top.spacing
+    end if
 
-  if m.textHeight <> prevTextHeight
-    updatelayout()
-  end if
+    if m.textHeight <> prevTextHeight
+        updatelayout()
+    end if
 end sub
 
 
 sub onBackgroundImageChange()
-  if m.top.backgroundUri <> ""
-    previousBackground = m.background
-    m.background = m.top.findNode("backgroundImage")
-    m.background.opacity = previousBackground.opacity
-    m.background.translation = previousBackground.translation
-    m.background.width = previousBackground.width
-    m.background.height = previousBackground.height
-    m.background.uri = m.top.backgroundUri
-    previousBackground.visible = false
-  end if
+    if m.top.backgroundUri <> ""
+        previousBackground = m.background
+        m.background = m.top.findNode("backgroundImage")
+        m.background.opacity = previousBackground.opacity
+        m.background.translation = previousBackground.translation
+        m.background.width = previousBackground.width
+        m.background.height = previousBackground.height
+        m.background.uri = m.top.backgroundUri
+        previousBackground.visible = false
+    end if
 end sub
 
 
 sub onBackgroundOpacityChange()
-  if m.background <> invalid
-    m.background.opacity = m.top.backgroundOpacity
-  end if
+    if m.background <> invalid
+        m.background.opacity = m.top.backgroundOpacity
+    end if
 end sub
 
 
 sub onTextPaddingChange()
-  if m.top.textPadding > 0
-    m.textPadding = m.top.textPadding
-  else
-    m.textPadding = 0
-  end if
-  updateLayout()
+    if m.top.textPadding > 0
+        m.textPadding = m.top.textPadding
+    else
+        m.textPadding = 0
+    end if
+    updateLayout()
 end sub
 
 
 sub onControlChange()
-  if m.top.control = "start"
-    ' opacity could be set to 0 by fade animation so restore it
-    m.loadingIndicatorGroup.opacity = 1
-    startAnimation()
-  else if m.top.control = "stop"
-    ' if there is fadeInterval set, fully dispose component before stopping spinning animation
-    if m.top.fadeInterval > 0
-      m.fadeAnimation.duration = m.top.fadeInterval
-      m.fadeAnimation.observeField("state", "onFadeAnimationStateChange")
-      m.fadeAnimation.control = "start"
-    else
-      stopAnimation()
+    if m.top.control = "start"
+        ' opacity could be set to 0 by fade animation so restore it
+        m.loadingIndicatorGroup.opacity = 1
+        startAnimation()
+    else if m.top.control = "stop"
+        ' if there is fadeInterval set, fully dispose component before stopping spinning animation
+        if m.top.fadeInterval > 0
+            m.fadeAnimation.duration = m.top.fadeInterval
+            m.fadeAnimation.observeField("state", "onFadeAnimationStateChange")
+            m.fadeAnimation.control = "start"
+        else
+            stopAnimation()
+        end if
     end if
-  end if
 end sub
 
 
 sub onFadeAnimationStateChange()
-  if m.fadeAnimation.state = "stopped"
-    stopAnimation()
-  end if
+    if m.fadeAnimation.state = "stopped"
+        stopAnimation()
+    end if
 end sub
 
 
 function getComponentWidth() as float
-  if m.top.width = 0
-    return getParentWidth()
-  else
-    return m.top.width
-  end if
+    if m.top.width = 0
+        return getParentWidth()
+    else
+        return m.top.width
+    end if
 end function
 
 
 function getComponentHeight() as float
-  if m.top.height = 0
-    return getParentHeight()
-  else
-    return m.top.height
-  end if
+    if m.top.height = 0
+        return getParentHeight()
+    else
+        return m.top.height
+    end if
 end function
 
 
 function getParentWidth() as float
-  if m.top.getParent() <> invalid and m.top.getParent().width <> invalid then
-    return m.top.getParent().width
-  else
-    return 1920
-  end if
+    if m.top.getParent() <> invalid and m.top.getParent().width <> invalid then
+        return m.top.getParent().width
+    else
+        return 1920
+    end if
 end function
 
 
 function getParentHeight() as float
-  if m.top.getParent() <> invalid and m.top.getParent().height <> invalid then
-    return m.top.getParent().height
-  else
-    return 1080
-  end if
+    if m.top.getParent() <> invalid and m.top.getParent().height <> invalid then
+        return m.top.getParent().height
+    else
+        return 1080
+    end if
 end function
 
 
 sub startAnimation()
-  m.rotationAnimation.control = "start"
-  m.top.state = "running"
+    m.rotationAnimation.control = "start"
+    m.top.state = "running"
 end sub
 
 
 sub stopAnimation()
-  m.rotationAnimation.control = "stop"
-  m.top.state = "stopped"
+    m.rotationAnimation.control = "stop"
+    m.top.state = "stopped"
 end sub
 
 
 function max(a as float, b as float) as float
-  if a > b
-    return a
-  else
-    return b
-  end if
+    if a > b
+        return a
+    else
+        return b
+    end if
 end function

--- a/components/shared/VideoConversionDialog/VideoConversionDialog.brs
+++ b/components/shared/VideoConversionDialog/VideoConversionDialog.brs
@@ -1,92 +1,92 @@
 sub init()
-  m.startConversionTask = createObject("roSGNode", "HttpTask")
-  m.checkConversionTask = createObject("roSGNode", "HttpTask")
-  m.fetchFileTask = createObject("roSGNode", "HttpTask")
+    m.startConversionTask = createObject("roSGNode", "HttpTask")
+    m.checkConversionTask = createObject("roSGNode", "HttpTask")
+    m.fetchFileTask = createObject("roSGNode", "HttpTask")
 
-  m.timer = createObject("roSGNode", "Timer")
-  m.timer.duration = 2
-  m.timer.observeField("fire", "onTimerFired")
+    m.timer = createObject("roSGNode", "Timer")
+    m.timer.duration = 2
+    m.timer.observeField("fire", "onTimerFired")
 end sub
 
 sub onFileIdChange()
-  m.top.convertedFile = {}
-  m.top.title = "Converting to MP4"
-  m.top.message = "Status: Starting..."
-  startConversion()
+    m.top.convertedFile = {}
+    m.top.title = "Converting to MP4"
+    m.top.message = "Status: Starting..."
+    startConversion()
 end sub
 
 sub startConversion()
-  m.startConversionTask.observeField("response", "onStartConversionResponse")
-  m.startConversionTask.url = ("/files/" + m.top.fileId.toStr() + "/mp4")
-  m.startConversionTask.method = "POST"
-  m.startConversionTask.control = "RUN"
+    m.startConversionTask.observeField("response", "onStartConversionResponse")
+    m.startConversionTask.url = ("/files/" + m.top.fileId.toStr() + "/mp4")
+    m.startConversionTask.method = "POST"
+    m.startConversionTask.control = "RUN"
 end sub
 
 sub onStartConversionResponse(obj)
-  m.startConversionTask.unobserveField("response")
-  data = parseJSON(obj.getData())
+    m.startConversionTask.unobserveField("response")
+    data = parseJSON(obj.getData())
 
-  if data <> invalid and data.status <> invalid and data.status = "OK"
-    checkConversionStatus()
-  else
-    m.top.message = "Status: ERROR"
-  end if
+    if data <> invalid and data.status <> invalid and data.status = "OK"
+        checkConversionStatus()
+    else
+        m.top.message = "Status: ERROR"
+    end if
 end sub
 
 sub checkConversionStatus()
-  m.checkConversionTask.observeField("response", "onCheckConversionStatusResponse")
-  m.checkConversionTask.url = ("/files/" + m.top.fileId.toStr() + "/mp4")
-  m.checkConversionTask.method = "GET"
-  m.checkConversionTask.control = "RUN"
+    m.checkConversionTask.observeField("response", "onCheckConversionStatusResponse")
+    m.checkConversionTask.url = ("/files/" + m.top.fileId.toStr() + "/mp4")
+    m.checkConversionTask.method = "GET"
+    m.checkConversionTask.control = "RUN"
 end sub
 
 sub onCheckConversionStatusResponse(obj)
-  m.checkConversionTask.unobserveField("response")
-  data = parseJSON(obj.getData())
+    m.checkConversionTask.unobserveField("response")
+    data = parseJSON(obj.getData())
 
-  if data <> invalid and data.mp4 <> invalid and data.mp4.status <> invalid
-    message = "Status: " + data.mp4.status
+    if data <> invalid and data.mp4 <> invalid and data.mp4.status <> invalid
+        message = "Status: " + data.mp4.status
 
-    if data.mp4.percent_done <> invalid
-      message = message + " (%" + data.mp4.percent_done.toStr() + ")"
-    end if
+        if data.mp4.percent_done <> invalid
+            message = message + " (%" + data.mp4.percent_done.toStr() + ")"
+        end if
 
-    m.top.message = message
+        m.top.message = message
 
-    if data.mp4.status = "COMPLETED"
-      onConversionCompleted()
+        if data.mp4.status = "COMPLETED"
+            onConversionCompleted()
+        else
+            m.timer.control = "start"
+        end if
     else
-      m.timer.control = "start"
+        m.top.message = "Status: ERROR"
     end if
-  else
-    m.top.message = "Status: ERROR"
-  end if
 end sub
 
 sub onTimerFired()
-  checkConversionStatus()
+    checkConversionStatus()
 end sub
 
 sub onConversionCompleted()
-  refetchConvertedFile()
+    refetchConvertedFile()
 end sub
 
 sub refetchConvertedFile()
-  m.fetchFileTask.observeField("response", "onFetchFileResponse")
-  m.fetchFileTask.url = ("/files/list?parent_id=" + m.top.fileId.toStr() + "&mp4_status_parent=1&stream_url_parent=1&mp4_stream_url_parent=1&video_metadata_parent=1")
-  m.fetchFileTask.method = "GET"
-  m.fetchFileTask.control = "RUN"
+    m.fetchFileTask.observeField("response", "onFetchFileResponse")
+    m.fetchFileTask.url = ("/files/list?parent_id=" + m.top.fileId.toStr() + "&mp4_status_parent=1&stream_url_parent=1&mp4_stream_url_parent=1&video_metadata_parent=1")
+    m.fetchFileTask.method = "GET"
+    m.fetchFileTask.control = "RUN"
 end sub
 
 sub onFetchFileResponse(obj)
-  m.fetchFileTask.unobserveField("response")
-  data = parseJSON(obj.getData())
+    m.fetchFileTask.unobserveField("response")
+    data = parseJSON(obj.getData())
 
-  if data <> invalid and data.parent <> invalid
-    m.top.convertedFile = data.parent
-    m.top.completed = "true"
-    m.top.close = "true"
-  else
-    m.top.message = "Status: ERROR"
-  end if
+    if data <> invalid and data.parent <> invalid
+        m.top.convertedFile = data.parent
+        m.top.completed = "true"
+        m.top.close = "true"
+    else
+        m.top.message = "Status: ERROR"
+    end if
 end sub

--- a/components/shared/utils.brs
+++ b/components/shared/utils.brs
@@ -64,7 +64,8 @@ function getScreenFromFileType(file_type) as String
 end function
 
 ''' File Not Supported Dialog
-function showFileNotSupportedDialog()
+function showFileNotSupportedDialog(callback = invalid)
+  m.fileNotSupportedDialogCallback = callback
   m.fileNotSupportedDialog = createObject("roSGNode", "Dialog")
   m.fileNotSupportedDialog.title = "Oops :("
   m.fileNotSupportedDialog.message = "We're unable to show these kind of files on this app (for now)"
@@ -74,12 +75,15 @@ end function
 
 function onFileNotSupportedDialogClosedBase()
   m.fileNotSupportedDialog.unobserveField("wasClosed")
-  if onFileNotSupportedDialogClosed <> invalid
-    onFileNotSupportedDialogClosed()
+  if m.fileNotSupportedDialogCallback <> invalid
+    callback = m.fileNotSupportedDialogCallback
+    m.fileNotSupportedDialogCallback = invalid
+    callback()
   end if
 end function
 
-function updateSetting(key, value)
+function updateSetting(key, value, callback = invalid)
+  m.updateSettingCallback = callback
   m.httpTask = createObject("roSGNode", "HttpTask")
   m.httpTask.observeField("response", "onUpdateSettingBase")
   m.httpTask.url = "/account/settings"
@@ -101,7 +105,9 @@ function onUpdateSettingBase(obj)
     m.global.user = user
   end if
 
-  if onUpdateSetting <> invalid
-    onUpdateSetting()
+  if m.updateSettingCallback <> invalid
+    callback = m.updateSettingCallback
+    m.updateSettingCallback = invalid
+    callback()
   end if
 end function

--- a/components/shared/utils.brs
+++ b/components/shared/utils.brs
@@ -1,113 +1,113 @@
-function toBool(str) as Boolean
-  return str = "true"
+function toBool(str) as boolean
+    return str = "true"
 end function
 
-function convertSize(file_size) as String
-  ' Size
-  u = 0
-  s = 1024
-  b = file_size
-  sizes = ["B", "KB", "MB", "GB", "TB"]
+function convertSize(file_size) as string
+    ' Size
+    u = 0
+    s = 1024
+    b = file_size
+    sizes = ["B", "KB", "MB", "GB", "TB"]
 
-  while b >= s or -b >= s
-    b = b / s
-    u = u + 1
-  end while
+    while b >= s or -b >= s
+        b = b / s
+        u = u + 1
+    end while
 
-  if u > 4
-    u = 4
-  end if
+    if u > 4
+        u = 4
+    end if
 
-  size = Fix(b).toStr() + " " + sizes[u]
-  return size
+    size = Fix(b).toStr() + " " + sizes[u]
+    return size
 end function
 
 function convertDate(datetime)
-  ' Date
-  date = CreateObject("roDateTime")
-  date.FromISO8601String(datetime)
-  return date.AsDateString("short-month-no-weekday")
+    ' Date
+    date = CreateObject("roDateTime")
+    date.FromISO8601String(datetime)
+    return date.AsDateString("short-month-no-weekday")
 end function
 
-function isFileSupported(file) as Boolean
-  return (file.file_type = "FOLDER" or file.file_type = "VIDEO" or file.file_type = "IMAGE" or file.file_type = "AUDIO")
+function isFileSupported(file) as boolean
+    return (file.file_type = "FOLDER" or file.file_type = "VIDEO" or file.file_type = "IMAGE" or file.file_type = "AUDIO")
 end function
 
 ''' send a callback to override navigation behaviour
 function navigateToFile(file, immediateBackFileId = invalid)
-  screen = getScreenFromFileType(file.file_type)
-  navigateTo(screen, file, immediateBackFileId)
+    screen = getScreenFromFileType(file.file_type)
+    navigateTo(screen, file, immediateBackFileId)
 end function
 
 function navigateTo(screen, file, immediateBackFileId)
-  m.top.navigate = {
-    id: screen,
-    params: {
-      fileId: file.id,
-      fileName: file.name,
-      immediateBackFileId: immediateBackFileId,
+    m.top.navigate = {
+        id: screen,
+        params: {
+            fileId: file.id,
+            fileName: file.name,
+            immediateBackFileId: immediateBackFileId,
+        }
     }
-  }
 end function
 
-function getScreenFromFileType(file_type) as String
-  screenMap = {
-    FOLDER: "filesScreen",
-    VIDEO: "videoScreen",
-    IMAGE: "imageScreen",
-    AUDIO: "audioScreen"
-  }
-  if screenMap.doesExist(file_type)
-    return screenMap[file_type]
-  end if
-  return invalid
+function getScreenFromFileType(file_type) as string
+    screenMap = {
+        FOLDER: "filesScreen",
+        VIDEO: "videoScreen",
+        IMAGE: "imageScreen",
+        AUDIO: "audioScreen"
+    }
+    if screenMap.doesExist(file_type)
+        return screenMap[file_type]
+    end if
+    return invalid
 end function
 
 ''' File Not Supported Dialog
 function showFileNotSupportedDialog(callback = invalid)
-  m.fileNotSupportedDialogCallback = callback
-  m.fileNotSupportedDialog = createObject("roSGNode", "Dialog")
-  m.fileNotSupportedDialog.title = "Oops :("
-  m.fileNotSupportedDialog.message = "We're unable to show these kind of files on this app (for now)"
-  m.fileNotSupportedDialog.observeField("wasClosed", "onFileNotSupportedDialogClosedBase")
-  m.top.showDialog = m.fileNotSupportedDialog
+    m.fileNotSupportedDialogCallback = callback
+    m.fileNotSupportedDialog = createObject("roSGNode", "Dialog")
+    m.fileNotSupportedDialog.title = "Oops :("
+    m.fileNotSupportedDialog.message = "We're unable to show these kind of files on this app (for now)"
+    m.fileNotSupportedDialog.observeField("wasClosed", "onFileNotSupportedDialogClosedBase")
+    m.top.showDialog = m.fileNotSupportedDialog
 end function
 
 function onFileNotSupportedDialogClosedBase()
-  m.fileNotSupportedDialog.unobserveField("wasClosed")
-  if m.fileNotSupportedDialogCallback <> invalid
-    callback = m.fileNotSupportedDialogCallback
-    m.fileNotSupportedDialogCallback = invalid
-    callback()
-  end if
+    m.fileNotSupportedDialog.unobserveField("wasClosed")
+    if m.fileNotSupportedDialogCallback <> invalid
+        callback = m.fileNotSupportedDialogCallback
+        m.fileNotSupportedDialogCallback = invalid
+        callback()
+    end if
 end function
 
 function updateSetting(key, value, callback = invalid)
-  m.updateSettingCallback = callback
-  m.httpTask = createObject("roSGNode", "HttpTask")
-  m.httpTask.observeField("response", "onUpdateSettingBase")
-  m.httpTask.url = "/account/settings"
+    m.updateSettingCallback = callback
+    m.httpTask = createObject("roSGNode", "HttpTask")
+    m.httpTask.observeField("response", "onUpdateSettingBase")
+    m.httpTask.url = "/account/settings"
 
-  payload = {}
-  payload.addReplace(key, value)
-  m.httpTask.body = payload
+    payload = {}
+    payload.addReplace(key, value)
+    m.httpTask.body = payload
 
-  m.tempSetting = {key: key, value: value}
-  m.httpTask.method = "POST"
-  m.httpTask.control = "RUN"
+    m.tempSetting = { key: key, value: value }
+    m.httpTask.method = "POST"
+    m.httpTask.control = "RUN"
 end function
 
 function onUpdateSettingBase(obj)
-  data = parseJSON(obj.getData())
-  if data <> invalid and data.status <> invalid and data.status = "OK"
-    user = m.global.user
-    user.settings[m.tempSetting.key] = m.tempSetting.value
-    m.global.user = user
-  end if
+    data = parseJSON(obj.getData())
+    if data <> invalid and data.status <> invalid and data.status = "OK"
+        user = m.global.user
+        user.settings[m.tempSetting.key] = m.tempSetting.value
+        m.global.user = user
+    end if
 
-  if m.updateSettingCallback <> invalid
-    callback = m.updateSettingCallback
-    m.updateSettingCallback = invalid
-    callback()
-  end if
+    if m.updateSettingCallback <> invalid
+        callback = m.updateSettingCallback
+        m.updateSettingCallback = invalid
+        callback()
+    end if
 end function

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -20,9 +20,9 @@ The Roku `manifest` is the source of truth for the checked-in app version. Relea
 
 - `manifest` owns `major_version`, `minor_version`, and zero-padded `build_version`
 - `package.json` uses the derived semantic version, for example `2.8.4`
-- `Makefile VERSION` uses the full semantic version for signed `.pkg` labels
+- `Makefile VERSION` uses the full semantic version for release prep compatibility
 
-During a semantic-release run, `scripts/prepare-release.ts <version>` verifies that semantic-release is not trying to publish a version lower than the manifest, syncs the manifest, `package.json`, and `Makefile`, builds the ZIP, and stages the hosted and GitHub Release artifacts. The release bot then commits the version fields back to `main` with `[skip ci]`, so the Git tag, Roku manifest, and package metadata stay aligned.
+During a semantic-release run, `scripts/prepare-release.ts <version>` verifies that semantic-release is not trying to publish a version lower than the manifest, syncs the manifest, `package.json`, and `Makefile`, builds the ZIP, and stages the hosted and GitHub Release artifacts. The release bot then commits the version fields back to `main` with `[skip ci]`, so the Git tag, Roku manifest, package metadata, and Makefile release field stay aligned.
 
 ## Flow
 

--- a/docs/SIDELOADING.md
+++ b/docs/SIDELOADING.md
@@ -71,8 +71,17 @@ If you want to sideload a local branch instead of the published ZIP:
 
 Useful commands:
 
+- `make smoke` runs the standard static checks and builds a fresh ZIP
 - `make check-roku-dev-target` checks that the Roku developer endpoint is reachable
-- `make verify` builds a fresh ZIP and runs the desktop BrightScript checker when available locally
+- `make live-test` runs read-only device reachability and state checks
+- `make live-test-launch` opens the installed developer app and reports active app state
+- `make live-test-install` builds, reinstalls, and launches this checkout on the device
+- `make launch` opens the sideloaded developer app on the configured Roku
+- `make active-app` prints the currently active Roku app from ECP
+- `make device-info` prints the configured Roku device metadata from ECP
+- `make console` attaches to the BrightScript debug console on port `8085`
+- `make verify` runs the Node-based Roku static checks and builds a fresh ZIP
 - `make artifact` creates `dist/apps/putio-roku-v2.zip`
 
-For the full contributor workflow, see [Contributing](../CONTRIBUTING.md)
+For hardware-backed debugging, see [Live Test](../live-test/README.md). For the
+full contributor workflow, see [Contributing](../CONTRIBUTING.md)

--- a/docs/SIDELOADING.md
+++ b/docs/SIDELOADING.md
@@ -74,6 +74,9 @@ Useful commands:
 - `make smoke` runs the standard static checks and builds a fresh ZIP
 - `make check-roku-dev-target` checks that the Roku developer endpoint is reachable
 - `make live-test` runs read-only device reachability and state checks
+- `make live-test-control` launches the sideloaded app, sends remote keypresses over ECP, and asserts the dev app stays active
+- `make live-test-press KEYS="Back Info"` sends explicit remote keypresses over ECP
+- `make live-test-deeplink CONTENT_ID=<file-id> [MEDIA_TYPE=movie]` launches the sideloaded app through Roku deep linking
 - `make live-test-launch` opens the installed developer app and reports active app state
 - `make live-test-install` builds, reinstalls, and launches this checkout on the device
 - `make launch` opens the sideloaded developer app on the configured Roku

--- a/live-test/README.md
+++ b/live-test/README.md
@@ -1,0 +1,83 @@
+# Live Test
+
+Hardware-backed checks for the put.io Roku app. Use these when a change needs
+proof from a real Roku device instead of only a ZIP build.
+
+## Setup
+
+Copy the sample environment file and fill in the local device values:
+
+```bash
+cp .env.example .env
+```
+
+Required for read-only device checks:
+
+```bash
+ROKU_DEV_TARGET=<roku-ip>
+```
+
+Required for sideload install checks:
+
+```bash
+ROKU_DEV_PASSWORD=<developer-mode-password>
+```
+
+Keep `.env` local. Device IPs, Developer Mode passwords, signing keys, and
+download tokens do not belong in git.
+
+Install the repo toolchain before running smoke or install checks:
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+## Commands
+
+```bash
+make smoke
+make live-test
+make live-test-launch
+make live-test-install
+make console
+```
+
+- `make smoke` runs BrighterScript/`bslint` and builds a fresh sideload ZIP.
+- `make live-test` proves the configured Roku responds to ECP, exposes the
+  developer installer, and returns active-app/device metadata.
+- `make live-test-launch` opens the installed developer app and prints the
+  active app state.
+- `make live-test-install` removes the existing developer app, installs this
+  checkout, launches it, and prints the active app state. It requires
+  `ROKU_DEV_PASSWORD`.
+- `make console` attaches to the BrightScript debug console on port `8085`.
+
+For a one-off install without saving the password in `.env`, pass it as a Make
+variable:
+
+```bash
+make ROKU_DEV_PASSWORD=<developer-mode-password> live-test-install
+```
+
+## Debug Loop
+
+1. Run `make smoke` before touching the device.
+2. Run `make live-test` to confirm the configured target is the expected Roku.
+3. Run `make live-test-install` after code changes that must be reproduced on
+   hardware.
+4. In another terminal, run `make console` before launching playback flows so
+   BrightScript compile/runtime/player logs are visible.
+
+If `make live-test` passes but `make live-test-install` fails with HTTP `401`,
+the device is reachable but `ROKU_DEV_PASSWORD` is missing or incorrect.
+
+## Readiness Grade
+
+- Bootable: partial. The app can be packaged locally and launched on a
+  configured developer-enabled Roku.
+- Testable: partial. `make smoke` and CI prove static checks plus packaging;
+  hardware behavior still needs a real device.
+- Observable: partial. ECP state and the BrightScript console are available
+  through Make targets.
+- Verifiable: partial. `make verify` is deterministic locally/CI; real
+  playback/subtitle proof is hardware-backed through this runbook.

--- a/live-test/README.md
+++ b/live-test/README.md
@@ -42,7 +42,7 @@ make smoke
 make live-test
 make live-test-control
 make live-test-press KEYS="Back Info"
-make live-test-deeplink CONTENT_ID=1587417579
+make live-test-deeplink CONTENT_ID=<file-id>
 make live-test-launch
 make live-test-install
 make console

--- a/live-test/README.md
+++ b/live-test/README.md
@@ -32,11 +32,17 @@ Install the repo toolchain before running smoke or install checks:
 pnpm install --frozen-lockfile
 ```
 
+The Make targets load `.env` automatically. If you call `pnpm roku:live`
+directly, export `ROKU_DEV_TARGET` in the shell first.
+
 ## Commands
 
 ```bash
 make smoke
 make live-test
+make live-test-control
+make live-test-press KEYS="Back Info"
+make live-test-deeplink CONTENT_ID=1587417579
 make live-test-launch
 make live-test-install
 make console
@@ -45,6 +51,13 @@ make console
 - `make smoke` runs BrighterScript/`bslint` and builds a fresh sideload ZIP.
 - `make live-test` proves the configured Roku responds to ECP, exposes the
   developer installer, and returns active-app/device metadata.
+- `make live-test-control` launches the sideloaded developer app, sends remote
+  keypresses over ECP, and asserts the developer app remains active.
+- `make live-test-press KEYS="Back Info"` sends explicit remote keypresses over
+  ECP. Use this for manual-but-headless navigation while watching console logs.
+- `make live-test-deeplink CONTENT_ID=<file-id> [MEDIA_TYPE=movie]` launches the
+  developer app through Roku deep linking. The app treats `contentID` as a
+  put.io video file id and opens the video details screen after authentication.
 - `make live-test-launch` opens the installed developer app and prints the
   active app state.
 - `make live-test-install` removes the existing developer app, installs this
@@ -63,9 +76,13 @@ make ROKU_DEV_PASSWORD=<developer-mode-password> live-test-install
 
 1. Run `make smoke` before touching the device.
 2. Run `make live-test` to confirm the configured target is the expected Roku.
-3. Run `make live-test-install` after code changes that must be reproduced on
+3. Run `make live-test-control` to prove the agent can launch and control the
+   app without the physical remote.
+4. Run `make live-test-deeplink CONTENT_ID=<file-id>` for playback bugs tied to
+   a known put.io video file.
+5. Run `make live-test-install` after code changes that must be reproduced on
    hardware.
-4. In another terminal, run `make console` before launching playback flows so
+6. In another terminal, run `make console` before launching playback flows so
    BrightScript compile/runtime/player logs are visible.
 
 If `make live-test` passes but `make live-test-install` fails with HTTP `401`,
@@ -80,4 +97,5 @@ the device is reachable but `ROKU_DEV_PASSWORD` is missing or incorrect.
 - Observable: partial. ECP state and the BrightScript console are available
   through Make targets.
 - Verifiable: partial. `make verify` is deterministic locally/CI; real
-  playback/subtitle proof is hardware-backed through this runbook.
+  playback/subtitle proof is hardware-backed through this runbook, with
+  headless launch and remote-control coverage through `make live-test-control`.

--- a/package.json
+++ b/package.json
@@ -5,12 +5,20 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
+    "build:roku": "bsc --project bsconfig.json",
+    "check:roku": "bslint --project bsconfig.json",
     "check": "sst version",
+    "format:roku": "bsfmt \"source/**/*.{brs,bs}\" \"components/**/*.{brs,bs}\" --check",
+    "format:roku:write": "bsfmt \"source/**/*.{brs,bs}\" \"components/**/*.{brs,bs}\" --write",
     "prepare:release": "node scripts/prepare-release.ts",
     "deploy:production": "sst deploy --stage production"
   },
   "devDependencies": {
+    "@rokucommunity/bslint": "0.8.43",
     "@types/node": "^24.12.2",
+    "brighterscript": "0.72.1",
+    "brighterscript-formatter": "1.7.25",
+    "roku-deploy": "3.17.3",
     "sst": "^4.13.1",
     "typescript": "^6.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -6,10 +6,12 @@
   "type": "module",
   "scripts": {
     "build:roku": "bsc --project bsconfig.json",
+    "check:live": "tsc --ignoreConfig --noEmit --strict --skipLibCheck --target ES2024 --module NodeNext --moduleResolution NodeNext --types node scripts/roku-live-test.ts",
     "check:roku": "bslint --project bsconfig.json",
     "check": "sst version",
     "format:roku": "bsfmt \"source/**/*.{brs,bs}\" \"components/**/*.{brs,bs}\" --check",
     "format:roku:write": "bsfmt \"source/**/*.{brs,bs}\" \"components/**/*.{brs,bs}\" --write",
+    "roku:live": "node scripts/roku-live-test.ts",
     "prepare:release": "node scripts/prepare-release.ts",
     "deploy:production": "sst deploy --stage production"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,21 @@ importers:
 
   .:
     devDependencies:
+      '@rokucommunity/bslint':
+        specifier: 0.8.43
+        version: 0.8.43(brighterscript@0.72.1)
       '@types/node':
         specifier: ^24.12.2
         version: 24.12.3
+      brighterscript:
+        specifier: 0.72.1
+        version: 0.72.1
+      brighterscript-formatter:
+        specifier: 1.7.25
+        version: 1.7.25
+      roku-deploy:
+        specifier: 3.17.3
+        version: 3.17.3
       sst:
         specifier: ^4.13.1
         version: 4.13.1
@@ -153,8 +165,47 @@ packages:
     resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
     engines: {node: '>=18.0.0'}
 
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
   '@nodable/entities@2.1.0':
     resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
+  '@postman/form-data@3.1.1':
+    resolution: {integrity: sha512-vjh8Q2a8S6UCm/KKs31XFJqEEgmbjBmpPNVV2eVav6905wyFAwaUOBGA1NPBI4ERH9MMZc6w0umFgM6WbEPMdg==}
+    engines: {node: '>= 6'}
+
+  '@postman/tough-cookie@4.1.3-postman.1':
+    resolution: {integrity: sha512-txpgUqZOnWYnUHZpHjkfb0IwVH4qJmyq77pPnJLlfhMtdCLMFTEeQHlzQiK906aaNCe4NEB5fGJHo9uzGbFMeA==}
+    engines: {node: '>=6'}
+
+  '@postman/tunnel-agent@0.6.8':
+    resolution: {integrity: sha512-2U42SmZW5G+suEcS++zB94sBWNO4qD4bvETGFRFDTqSpYl5ksfjcPqzYpgQgXgUmb6dfz+fAGbkcRamounGm0w==}
+
+  '@rokucommunity/bslib@0.1.1':
+    resolution: {integrity: sha512-2ox6EUL+UTtccTbD4dbVjZK3QHa0PHCqpoKMF8lZz9ayzzEP3iVPF8KZR6hOi6bxsIcbGXVjqmtCVkpC4P9SrA==}
+
+  '@rokucommunity/bslint@0.8.43':
+    resolution: {integrity: sha512-B0XB+IPHr26Lci6Wn5iHSdOLTxnSNQKpWvGAM8NovMOPIVXoy/1UPicPu2Lvy6qkbtZQS0ZWZdGicCMubR+pjg==}
+    hasBin: true
+    peerDependencies:
+      brighterscript: '>= 0.59.0 < 1'
+
+  '@rokucommunity/logger@0.3.11':
+    resolution: {integrity: sha512-yQWa+rRVYkZeEYFePHzNtB6/DL+wPjjL/xt9wM0gQPDugSl8kJZ3ywyUtrFS+y/wzY0Nc2M+1704GVx0vdOO9A==}
 
   '@smithy/config-resolver@4.4.17':
     resolution: {integrity: sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==}
@@ -348,14 +399,251 @@ packages:
     resolution: {integrity: sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==}
     engines: {node: '>=18.0.0'}
 
+  '@types/caseless@0.12.5':
+    resolution: {integrity: sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==}
+
   '@types/node@24.12.3':
     resolution: {integrity: sha512-8oljBDGun9cIsZRJR6fkihn0TSXJI0UDOOhncYaERq6M0JMDoPLxyscwruJcb4GKS6dvK/d8xebYBg27h/duaQ==}
+
+  '@types/request@2.48.13':
+    resolution: {integrity: sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+
+  '@xml-tools/parser@1.0.11':
+    resolution: {integrity: sha512-aKqQ077XnR+oQtHJlrAflaZaL7qZsulWc/i/ZEooar5JiWj1eLt0+Wg28cpa+XLney107wXqneC+oG1IZvxkTA==}
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@3.2.1:
+    resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
+    engines: {node: '>=4'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
+
+  array-flat-polyfill@1.0.1:
+    resolution: {integrity: sha512-hfJmKupmQN0lwi0xG6FQ5U8Rd97RnIERplymOv/qpq8AoNKPPAnxJadjFA23FNWm88wykh9HmpLJUUwUtNU/iw==}
+    engines: {node: '>=6.0.0'}
+
+  asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+
+  assert-plus@1.0.0:
+    resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
+    engines: {node: '>=0.8'}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  aws-sign2@0.7.0:
+    resolution: {integrity: sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==}
+
+  aws4@1.13.2:
+    resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
 
   aws4fetch@1.0.18:
     resolution: {integrity: sha512-3Cf+YaUl07p24MoQ46rFwulAmiyCwH2+1zw1ZyPAX5OtJ34Hh185DwB8y/qRLb6cYYYtSFJ9pthyLc0MD4e8sQ==}
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  bcrypt-pbkdf@1.0.2:
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
+
+  binary-extensions@2.3.0:
+    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
+    engines: {node: '>=8'}
+
+  bluebird@2.11.0:
+    resolution: {integrity: sha512-UfFSr22dmHPQqPP9XWHRhq+gWnHCYguQGkXQlbyPtW5qTnhFWA8/iXg765tH0cAjy7l/zPJ1aBTO0g5XgA7kvQ==}
+
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  brighterscript-formatter@1.7.25:
+    resolution: {integrity: sha512-bqVd/3PufKiI/Qr+lLa9IqM/d7v8jfbLYLKHczBKjgP/Ab+n8GQrGkjXxI2vAfc0RuEr/7bWMLFjJQbRciW+FQ==}
+    hasBin: true
+
+  brighterscript@0.72.1:
+    resolution: {integrity: sha512-WwImSBlnmW+wSW5c8uH86/g0C2pdQf2utivOkJKssDe8cSqRrd4T5YRDWa5pkZlgY9otcp867ZSKHAqk1Y4XGA==}
+    hasBin: true
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
+  camelcase@5.3.1:
+    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
+    engines: {node: '>=6'}
+
+  caseless@0.12.0:
+    resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
+
+  chalk@2.4.2:
+    resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
+    engines: {node: '>=4'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  chevrotain@7.1.1:
+    resolution: {integrity: sha512-wy3mC1x4ye+O+QkEinVJkPf5u2vsrDIYW9G7ZuwFl6v/Yu0LwUuT2POsb+NUWApebyxfkQq6+yDfRExbnI5rcw==}
+
+  chevrotain@7.1.2:
+    resolution: {integrity: sha512-9bQsXVQ7UAvzMs7iUBBJ9Yv//exOy7bIR3PByOEk4M64vIE/LsiOiX7VIkMF/vEMlrSStwsaE884Bp9CpjtC5g==}
+
+  chokidar@3.6.0:
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
+    engines: {node: '>= 8.10.0'}
+
+  clear@0.1.0:
+    resolution: {integrity: sha512-qMjRnoL+JDPJHeLePZJuao6+8orzHMGP04A8CdwCNsKhRbOnKRjefxONR7bwILT3MHecxKBjHkKL/tkZ8r4Uzw==}
+
+  cliui@6.0.0:
+    resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
+
+  cliui@7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
+  color-convert@1.9.3:
+    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.3:
+    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  core-util-is@1.0.2:
+    resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
+
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cross-platform-clear-console@2.3.0:
+    resolution: {integrity: sha512-To+sJ6plHHC6k5DfdvSVn6F1GRGJh/R6p76bCpLbyMyHEmbqFyuMAeGwDcz/nGDWH3HUcjFTTX9iUSCzCg9Eiw==}
+
+  dashdash@1.14.1:
+    resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
+    engines: {node: '>=0.10'}
+
+  date-fns@2.30.0:
+    resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
+    engines: {node: '>=0.11'}
+
+  dateformat@3.0.3:
+    resolution: {integrity: sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==}
+
+  dayjs@1.11.20:
+    resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
+
+  debounce-promise@3.1.2:
+    resolution: {integrity: sha512-rZHcgBkbYavBeD9ej6sP56XfG53d51CD4dnaw989YX/nZ/ZJfgRx/9ePKmTNiUiyQvh4mtrMoS3OAWW+yoYtpg==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ecc-jsbn@0.1.2:
+    resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  escape-string-regexp@1.0.5:
+    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
+    engines: {node: '>=0.8.0'}
+
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  extsprintf@1.3.0:
+    resolution: {integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==}
+    engines: {'0': node >=0.6.0}
+
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
 
   fast-xml-builder@1.1.9:
     resolution: {integrity: sha512-jcyKVSEX13iseJqg7n/KWw+xnu/7fdrZ333Fac54KjHDIELVCfDDJXYIm6DTJ0Su4gSzrhqiK0DzY/wZbF40mw==}
@@ -364,30 +652,457 @@ packages:
     resolution: {integrity: sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==}
     hasBin: true
 
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  file-url@3.0.0:
+    resolution: {integrity: sha512-g872QGsHexznxkIAdK8UiZRe7SkE6kvylShU4Nsj8NvfvZag7S0QuQ4IgvPDkk75HxgjIVDwycFTDAgIiO4nDA==}
+    engines: {node: '>=8'}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
+
+  forever-agent@0.6.1:
+    resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
+
+  form-data@2.5.5:
+    resolution: {integrity: sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==}
+    engines: {node: '>= 0.12'}
+
+  fs-extra@10.1.0:
+    resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
+    engines: {node: '>=12'}
+
+  fs-extra@7.0.1:
+    resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
+    engines: {node: '>=6 <7 || >=8'}
+
+  fs-extra@8.1.0:
+    resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
+    engines: {node: '>=6 <7 || >=8'}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  getpass@0.1.7:
+    resolution: {integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==}
+
+  glob-all@3.3.1:
+    resolution: {integrity: sha512-Y+ESjdI7ZgMwfzanHZYQ87C59jOO0i+Hd+QYtVt9PhLi6d8wlOpzQnfBxWUlaTuAoR3TkybLqqbIoWveU4Ji7Q==}
+    hasBin: true
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  has-flag@3.0.0:
+    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
+    engines: {node: '>=4'}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  http-signature@1.4.0:
+    resolution: {integrity: sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==}
+    engines: {node: '>=0.10'}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
+  is-binary-path@2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  is-typedarray@1.0.0:
+    resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
+
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
+  isstream@0.1.2:
+    resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
+
   jose@4.15.9:
     resolution: {integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==}
 
   jose@5.2.3:
     resolution: {integrity: sha512-KUXdbctm1uHVL8BYhnyHkgp3zDX5KW8ZhAKVFEfUbU2P8Alpzjb+48hHvjOdQIyPshoblhzsuqOwEEAbtHVirA==}
 
+  jsbn@0.1.1:
+    resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+
+  json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
+  jsonc-parser@2.3.1:
+    resolution: {integrity: sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==}
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
+  jsonfile@4.0.0:
+    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
+
+  jsonfile@6.2.1:
+    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
+
+  jsprim@2.0.2:
+    resolution: {integrity: sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==}
+    engines: {'0': node >=0.6.0}
+
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
+
+  locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
+
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
+  long@3.2.0:
+    resolution: {integrity: sha512-ZYvPPOMqUwPoDsbJaR10iQJYnMuZhRTvHYl62ErLIEX7RgFlziSBUUvrt3OVfc47QlHHpzPZYP17g3Fv7oeJkg==}
+    engines: {node: '>=0.6'}
+
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
+
+  luxon@2.5.2:
+    resolution: {integrity: sha512-Yg7/RDp4nedqmLgyH0LwgGRvMEKVzKbUdkBYyCosbHgJ+kaOUx0qzSiSatVc3DFygnirTPYnMM2P5dg2uH1WvA==}
+    engines: {node: '>=12'}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  moment@2.30.1:
+    resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
+  oauth-sign@0.9.0:
+    resolution: {integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==}
 
   object-hash@2.2.0:
     resolution: {integrity: sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==}
     engines: {node: '>= 6'}
 
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   oidc-token-hash@5.2.0:
     resolution: {integrity: sha512-6gj2m8cJZ+iSW8bm0FXdGF0YhIQbKrfP4yWTNzxc31U6MOjfEmB1rHvlYvxI1B7t7BCi1F2vYTT6YhtQRG4hxw==}
     engines: {node: ^10.13.0 || >=12.0.0}
 
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
   openid-client@5.6.4:
     resolution: {integrity: sha512-T1h3B10BRPKfcObdBklX639tVz+xh34O7GjofqrqiAQdm7eHsQ00ih18x6wuJ/E6FxdtS2u3FmUGPDeEcMwzNA==}
+
+  p-limit@1.3.0:
+    resolution: {integrity: sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==}
+    engines: {node: '>=4'}
+
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
+  p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
+
+  p-reflect@1.0.0:
+    resolution: {integrity: sha512-rlngKS+EX3nvI7xIzA0xKNVEAguWdIqAZVbn02z1m73ehXBdX66aTdD0bCvIu0cDwbU3TK9w3RYrppKpO3EnKQ==}
+    engines: {node: '>=4'}
+
+  p-settle@2.1.0:
+    resolution: {integrity: sha512-NHFIUYc+fQTFRrzzAugq0l1drwi57PB522smetcY8C/EoTYs6cU/fC6TJj0N3rq5NhhJJbhf0VGWziL3jZDnjA==}
+    engines: {node: '>=4'}
+
+  p-try@1.0.0:
+    resolution: {integrity: sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==}
+    engines: {node: '>=4'}
+
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
+
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
+  parse-ms@2.1.0:
+    resolution: {integrity: sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==}
+    engines: {node: '>=6'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
 
   path-expression-matcher@1.5.0:
     resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
     engines: {node: '>=14.0.0'}
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
+  postman-request@2.88.1-postman.48:
+    resolution: {integrity: sha512-E32FGh8ig2KDvzo4Byi7Ibr+wK2gNKPSqXoNsvjdCHgDBxSK4sCUwv+aa3zOBUwfiibPImHMy0WdlDSSCTqTuw==}
+    engines: {node: '>= 16'}
+
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
+  psl@1.15.0:
+    resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  qs@6.14.2:
+    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
+    engines: {node: '>=0.6'}
+
+  querystringify@2.2.0:
+    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
+  readdirp@3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
+
+  readline@1.3.0:
+    resolution: {integrity: sha512-k2d6ACCkiNYz222Fs/iNze30rRJ1iIicW7JuX/7/cozvih6YCkFZH+J6mAFDVgv0dRBaAyr4jDqC95R2y4IADg==}
+
+  regexp-to-ast@0.5.0:
+    resolution: {integrity: sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-main-filename@2.0.0:
+    resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
+
+  require-relative@0.8.7:
+    resolution: {integrity: sha512-AKGr4qvHiryxRb19m3PsLRGuKVAbJLUD7E6eOaHkfKhwc+vSgVOCY5xNvm9EkolBKTOf0GrQAZKLimOCz81Khg==}
+
+  requires-port@1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  roku-deploy@3.17.3:
+    resolution: {integrity: sha512-u9xv3ug8Hfhdo0B1+YE8xzaKBuS3hahM4g4gfAief10b5WkT+4jSLGMa/84EUD/HfEDj8h3Dg7Q3gm0StB8B4Q==}
+    hasBin: true
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safe-json-stringify@1.2.0:
+    resolution: {integrity: sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sax@1.6.0:
+    resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
+    engines: {node: '>=11.0.0'}
+
+  semver@7.8.0:
+    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  serialize-error@7.0.1:
+    resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
+    engines: {node: '>=10'}
+
+  serialize-error@8.1.0:
+    resolution: {integrity: sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==}
+    engines: {node: '>=10'}
+
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  socks-proxy-agent@8.0.5:
+    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+    engines: {node: '>= 14'}
+
+  socks@2.8.9:
+    resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
+  source-map@0.7.4:
+    resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
+    engines: {node: '>= 8'}
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
+  sshpk@1.18.0:
+    resolution: {integrity: sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
 
   sst-darwin-arm64@4.13.1:
     resolution: {integrity: sha512-gGwfgZGOsulU6iGeZJtxP5BpSZFsRUy1dG/yTqJa++n1P1APWXZC64u2qRHm6rdwLAjEeWaCQ9k7ouKgn0zh5Q==}
@@ -433,11 +1148,55 @@ packages:
     resolution: {integrity: sha512-FKzhWuqV5NPhFWH7b+Ktf5+Mvox6DCMc8iOrjaS3mkjnnmyEcOZq7HNx2/ZlIcBwgOZE9sCPR3ot1zXtXkXzZg==}
     hasBin: true
 
+  stream-length@1.0.2:
+    resolution: {integrity: sha512-aI+qKFiwoDV4rsXiS7WRoCt+v2RX1nUj17+KJC5r2gfh5xoSJIfP6Y3Do/HtvesFcTSWthIuJ3l1cvKQY/+nZg==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
   strnum@2.3.0:
     resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
 
+  supports-color@5.5.0:
+    resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
+    engines: {node: '>=4'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  temp-dir@2.0.0:
+    resolution: {integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==}
+    engines: {node: '>=8'}
+
+  thenby@1.4.1:
+    resolution: {integrity: sha512-D5a/bO0KdalOE3q8MlrRmSxjbKZHT3MQmXkJP+r97Vw8MMwOZKOwUSEyTtK7eSMj2y0kyAjpYMRMZmmLw1FtNQ==}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tweetnacl@0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+
+  type-fest@0.13.1:
+    resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
+    engines: {node: '>=10'}
+
+  type-fest@0.20.2:
+    resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
+    engines: {node: '>=10'}
 
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
@@ -447,8 +1206,108 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
+  universalify@0.1.2:
+    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
+    engines: {node: '>= 4.0.0'}
+
+  universalify@0.2.0:
+    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
+    engines: {node: '>= 4.0.0'}
+
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
+
+  url-parse@1.5.10:
+    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+
+  verror@1.10.0:
+    resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
+    engines: {'0': node >=0.6.0}
+
+  vscode-jsonrpc@8.2.0:
+    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
+    engines: {node: '>=14.0.0'}
+
+  vscode-languageserver-protocol@3.17.5:
+    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
+
+  vscode-languageserver-textdocument@1.0.12:
+    resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
+
+  vscode-languageserver-types@3.17.5:
+    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
+
+  vscode-languageserver@9.0.1:
+    resolution: {integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==}
+    hasBin: true
+
+  vscode-uri@3.1.0:
+    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+
+  which-module@2.0.1:
+    resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
+
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  xml2js@0.5.0:
+    resolution: {integrity: sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==}
+    engines: {node: '>=4.0.0'}
+
+  xmlbuilder@11.0.1:
+    resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
+    engines: {node: '>=4.0'}
+
+  y18n@4.0.3:
+    resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  yargs-parser@18.1.3:
+    resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
+    engines: {node: '>=6'}
+
+  yargs-parser@20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@15.4.1:
+    resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
+    engines: {node: '>=8'}
+
+  yargs@16.2.0:
+    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
+    engines: {node: '>=10'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
 
 snapshots:
 
@@ -828,7 +1687,57 @@ snapshots:
 
   '@aws/lambda-invoke-store@0.2.4': {}
 
+  '@babel/runtime@7.29.2': {}
+
   '@nodable/entities@2.1.0': {}
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
+
+  '@postman/form-data@3.1.1':
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
+
+  '@postman/tough-cookie@4.1.3-postman.1':
+    dependencies:
+      psl: 1.15.0
+      punycode: 2.3.1
+      universalify: 0.2.0
+      url-parse: 1.5.10
+
+  '@postman/tunnel-agent@0.6.8':
+    dependencies:
+      safe-buffer: 5.2.1
+
+  '@rokucommunity/bslib@0.1.1': {}
+
+  '@rokucommunity/bslint@0.8.43(brighterscript@0.72.1)':
+    dependencies:
+      brighterscript: 0.72.1
+      fs-extra: 10.1.0
+      jsonc-parser: 2.3.1
+      minimatch: 3.1.5
+      yargs: 15.4.1
+
+  '@rokucommunity/logger@0.3.11':
+    dependencies:
+      chalk: 4.1.2
+      date-fns: 2.30.0
+      fs-extra: 10.1.0
+      parse-ms: 2.1.0
+      safe-json-stringify: 1.2.0
+      serialize-error: 8.1.0
 
   '@smithy/config-resolver@4.4.17':
     dependencies:
@@ -1135,13 +2044,289 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@types/caseless@0.12.5': {}
+
   '@types/node@24.12.3':
     dependencies:
       undici-types: 7.16.0
 
+  '@types/request@2.48.13':
+    dependencies:
+      '@types/caseless': 0.12.5
+      '@types/node': 24.12.3
+      '@types/tough-cookie': 4.0.5
+      form-data: 2.5.5
+
+  '@types/tough-cookie@4.0.5': {}
+
+  '@xml-tools/parser@1.0.11':
+    dependencies:
+      chevrotain: 7.1.1
+
+  agent-base@7.1.4: {}
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@3.2.1:
+    dependencies:
+      color-convert: 1.9.3
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  anymatch@3.1.3:
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.2
+
+  array-flat-polyfill@1.0.1: {}
+
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  assert-plus@1.0.0: {}
+
+  asynckit@0.4.0: {}
+
+  aws-sign2@0.7.0: {}
+
+  aws4@1.13.2: {}
+
   aws4fetch@1.0.18: {}
 
+  balanced-match@1.0.2: {}
+
+  bcrypt-pbkdf@1.0.2:
+    dependencies:
+      tweetnacl: 0.14.5
+
+  binary-extensions@2.3.0: {}
+
+  bluebird@2.11.0: {}
+
   bowser@2.14.1: {}
+
+  brace-expansion@1.1.14:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  brighterscript-formatter@1.7.25:
+    dependencies:
+      brighterscript: 0.72.1
+      glob-all: 3.3.1
+      jsonc-parser: 3.3.1
+      source-map: 0.7.4
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - supports-color
+
+  brighterscript@0.72.1:
+    dependencies:
+      '@rokucommunity/bslib': 0.1.1
+      '@rokucommunity/logger': 0.3.11
+      '@xml-tools/parser': 1.0.11
+      array-flat-polyfill: 1.0.1
+      chalk: 2.4.2
+      chevrotain: 7.1.2
+      chokidar: 3.6.0
+      clear: 0.1.0
+      cross-platform-clear-console: 2.3.0
+      debounce-promise: 3.1.2
+      eventemitter3: 4.0.7
+      fast-glob: 3.3.3
+      file-url: 3.0.0
+      fs-extra: 8.1.0
+      ignore: 5.3.2
+      jsonc-parser: 2.3.1
+      lodash.isequal: 4.5.0
+      long: 3.2.0
+      luxon: 2.5.2
+      micromatch: 4.0.8
+      minimatch: 3.1.5
+      moment: 2.30.1
+      p-settle: 2.1.0
+      parse-ms: 2.1.0
+      readline: 1.3.0
+      require-relative: 0.8.7
+      roku-deploy: 3.17.3
+      safe-json-stringify: 1.2.0
+      semver: 7.8.0
+      serialize-error: 7.0.1
+      source-map: 0.7.6
+      thenby: 1.4.1
+      vscode-languageserver: 9.0.1
+      vscode-languageserver-protocol: 3.17.5
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-types: 3.17.5
+      vscode-uri: 3.1.0
+      xml2js: 0.5.0
+      yargs: 16.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
+  camelcase@5.3.1: {}
+
+  caseless@0.12.0: {}
+
+  chalk@2.4.2:
+    dependencies:
+      ansi-styles: 3.2.1
+      escape-string-regexp: 1.0.5
+      supports-color: 5.5.0
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  chevrotain@7.1.1:
+    dependencies:
+      regexp-to-ast: 0.5.0
+
+  chevrotain@7.1.2:
+    dependencies:
+      regexp-to-ast: 0.5.0
+
+  chokidar@3.6.0:
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.3
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  clear@0.1.0: {}
+
+  cliui@6.0.0:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
+
+  cliui@7.0.4:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  color-convert@1.9.3:
+    dependencies:
+      color-name: 1.1.3
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.3: {}
+
+  color-name@1.1.4: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
+  concat-map@0.0.1: {}
+
+  core-util-is@1.0.2: {}
+
+  core-util-is@1.0.3: {}
+
+  cross-platform-clear-console@2.3.0: {}
+
+  dashdash@1.14.1:
+    dependencies:
+      assert-plus: 1.0.0
+
+  date-fns@2.30.0:
+    dependencies:
+      '@babel/runtime': 7.29.2
+
+  dateformat@3.0.3: {}
+
+  dayjs@1.11.20: {}
+
+  debounce-promise@3.1.2: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  decamelize@1.2.0: {}
+
+  delayed-stream@1.0.0: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ecc-jsbn@0.1.2:
+    dependencies:
+      jsbn: 0.1.1
+      safer-buffer: 2.1.2
+
+  emoji-regex@8.0.0: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.3
+
+  escalade@3.2.0: {}
+
+  escape-string-regexp@1.0.5: {}
+
+  eventemitter3@4.0.7: {}
+
+  extend@3.0.2: {}
+
+  extsprintf@1.3.0: {}
+
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
 
   fast-xml-builder@1.1.9:
     dependencies:
@@ -1154,17 +2339,250 @@ snapshots:
       path-expression-matcher: 1.5.0
       strnum: 2.3.0
 
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
+
+  file-url@3.0.0: {}
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  find-up@4.1.0:
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
+
+  forever-agent@0.6.1: {}
+
+  form-data@2.5.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.3
+      mime-types: 2.1.35
+      safe-buffer: 5.2.1
+
+  fs-extra@10.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
+
+  fs-extra@7.0.1:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 4.0.0
+      universalify: 0.1.2
+
+  fs-extra@8.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 4.0.0
+      universalify: 0.1.2
+
+  fs.realpath@1.0.0: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  get-caller-file@2.0.5: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  getpass@0.1.7:
+    dependencies:
+      assert-plus: 1.0.0
+
+  glob-all@3.3.1:
+    dependencies:
+      glob: 7.2.3
+      yargs: 15.4.1
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob@7.2.3:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.5
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+
+  gopd@1.2.0: {}
+
+  graceful-fs@4.2.11: {}
+
+  has-flag@3.0.0: {}
+
+  has-flag@4.0.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  http-signature@1.4.0:
+    dependencies:
+      assert-plus: 1.0.0
+      jsprim: 2.0.2
+      sshpk: 1.18.0
+
+  ignore@5.3.2: {}
+
+  immediate@3.0.6: {}
+
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+
+  inherits@2.0.4: {}
+
+  ip-address@10.2.0: {}
+
+  is-binary-path@2.1.0:
+    dependencies:
+      binary-extensions: 2.3.0
+
+  is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-number@7.0.0: {}
+
+  is-typedarray@1.0.0: {}
+
+  isarray@1.0.0: {}
+
+  isstream@0.1.2: {}
+
   jose@4.15.9: {}
 
   jose@5.2.3: {}
+
+  jsbn@0.1.1: {}
+
+  json-schema@0.4.0: {}
+
+  json-stringify-safe@5.0.1: {}
+
+  jsonc-parser@2.3.1: {}
+
+  jsonc-parser@3.3.1: {}
+
+  jsonfile@4.0.0:
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
+  jsonfile@6.2.1:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
+  jsprim@2.0.2:
+    dependencies:
+      assert-plus: 1.0.0
+      extsprintf: 1.3.0
+      json-schema: 0.4.0
+      verror: 1.10.0
+
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
+
+  locate-path@5.0.0:
+    dependencies:
+      p-locate: 4.1.0
+
+  lodash.isequal@4.5.0: {}
+
+  lodash@4.18.1: {}
+
+  long@3.2.0: {}
 
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
 
+  luxon@2.5.2: {}
+
+  math-intrinsics@1.1.0: {}
+
+  merge2@1.4.1: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.14
+
+  moment@2.30.1: {}
+
+  ms@2.1.3: {}
+
+  normalize-path@3.0.0: {}
+
+  oauth-sign@0.9.0: {}
+
   object-hash@2.2.0: {}
 
+  object-inspect@1.13.4: {}
+
   oidc-token-hash@5.2.0: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   openid-client@5.6.4:
     dependencies:
@@ -1173,7 +2591,218 @@ snapshots:
       object-hash: 2.2.0
       oidc-token-hash: 5.2.0
 
+  p-limit@1.3.0:
+    dependencies:
+      p-try: 1.0.0
+
+  p-limit@2.3.0:
+    dependencies:
+      p-try: 2.2.0
+
+  p-locate@4.1.0:
+    dependencies:
+      p-limit: 2.3.0
+
+  p-reflect@1.0.0: {}
+
+  p-settle@2.1.0:
+    dependencies:
+      p-limit: 1.3.0
+      p-reflect: 1.0.0
+
+  p-try@1.0.0: {}
+
+  p-try@2.2.0: {}
+
+  pako@1.0.11: {}
+
+  parse-ms@2.1.0: {}
+
+  path-exists@4.0.0: {}
+
   path-expression-matcher@1.5.0: {}
+
+  path-is-absolute@1.0.1: {}
+
+  picomatch@2.3.2: {}
+
+  postman-request@2.88.1-postman.48:
+    dependencies:
+      '@postman/form-data': 3.1.1
+      '@postman/tough-cookie': 4.1.3-postman.1
+      '@postman/tunnel-agent': 0.6.8
+      aws-sign2: 0.7.0
+      aws4: 1.13.2
+      caseless: 0.12.0
+      combined-stream: 1.0.8
+      extend: 3.0.2
+      forever-agent: 0.6.1
+      http-signature: 1.4.0
+      is-typedarray: 1.0.0
+      isstream: 0.1.2
+      json-stringify-safe: 5.0.1
+      mime-types: 2.1.35
+      oauth-sign: 0.9.0
+      qs: 6.14.2
+      safe-buffer: 5.2.1
+      socks-proxy-agent: 8.0.5
+      stream-length: 1.0.2
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  process-nextick-args@2.0.1: {}
+
+  psl@1.15.0:
+    dependencies:
+      punycode: 2.3.1
+
+  punycode@2.3.1: {}
+
+  qs@6.14.2:
+    dependencies:
+      side-channel: 1.1.0
+
+  querystringify@2.2.0: {}
+
+  queue-microtask@1.2.3: {}
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
+  readdirp@3.6.0:
+    dependencies:
+      picomatch: 2.3.2
+
+  readline@1.3.0: {}
+
+  regexp-to-ast@0.5.0: {}
+
+  require-directory@2.1.1: {}
+
+  require-main-filename@2.0.0: {}
+
+  require-relative@0.8.7: {}
+
+  requires-port@1.0.0: {}
+
+  reusify@1.1.0: {}
+
+  roku-deploy@3.17.3:
+    dependencies:
+      '@types/request': 2.48.13
+      chalk: 2.4.2
+      dateformat: 3.0.3
+      dayjs: 1.11.20
+      fast-glob: 3.3.3
+      fs-extra: 7.0.1
+      is-glob: 4.0.3
+      jsonc-parser: 2.3.1
+      jszip: 3.10.1
+      lodash: 4.18.1
+      micromatch: 4.0.8
+      moment: 2.30.1
+      parse-ms: 2.1.0
+      postman-request: 2.88.1-postman.48
+      semver: 7.8.0
+      temp-dir: 2.0.0
+      xml2js: 0.5.0
+    transitivePeerDependencies:
+      - supports-color
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
+  safe-buffer@5.1.2: {}
+
+  safe-buffer@5.2.1: {}
+
+  safe-json-stringify@1.2.0: {}
+
+  safer-buffer@2.1.2: {}
+
+  sax@1.6.0: {}
+
+  semver@7.8.0: {}
+
+  serialize-error@7.0.1:
+    dependencies:
+      type-fest: 0.13.1
+
+  serialize-error@8.1.0:
+    dependencies:
+      type-fest: 0.20.2
+
+  set-blocking@2.0.0: {}
+
+  setimmediate@1.0.5: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  smart-buffer@4.2.0: {}
+
+  socks-proxy-agent@8.0.5:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      socks: 2.8.9
+    transitivePeerDependencies:
+      - supports-color
+
+  socks@2.8.9:
+    dependencies:
+      ip-address: 10.2.0
+      smart-buffer: 4.2.0
+
+  source-map@0.7.4: {}
+
+  source-map@0.7.6: {}
+
+  sshpk@1.18.0:
+    dependencies:
+      asn1: 0.2.6
+      assert-plus: 1.0.0
+      bcrypt-pbkdf: 1.0.2
+      dashdash: 1.14.1
+      ecc-jsbn: 0.1.2
+      getpass: 0.1.7
+      jsbn: 0.1.1
+      safer-buffer: 2.1.2
+      tweetnacl: 0.14.5
 
   sst-darwin-arm64@4.13.1:
     optional: true
@@ -1217,12 +2846,160 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  stream-length@1.0.2:
+    dependencies:
+      bluebird: 2.11.0
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
   strnum@2.3.0: {}
 
+  supports-color@5.5.0:
+    dependencies:
+      has-flag: 3.0.0
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  temp-dir@2.0.0: {}
+
+  thenby@1.4.1: {}
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
   tslib@2.8.1: {}
+
+  tweetnacl@0.14.5: {}
+
+  type-fest@0.13.1: {}
+
+  type-fest@0.20.2: {}
 
   typescript@6.0.3: {}
 
   undici-types@7.16.0: {}
 
+  universalify@0.1.2: {}
+
+  universalify@0.2.0: {}
+
+  universalify@2.0.1: {}
+
+  url-parse@1.5.10:
+    dependencies:
+      querystringify: 2.2.0
+      requires-port: 1.0.0
+
+  util-deprecate@1.0.2: {}
+
+  uuid@8.3.2: {}
+
+  verror@1.10.0:
+    dependencies:
+      assert-plus: 1.0.0
+      core-util-is: 1.0.2
+      extsprintf: 1.3.0
+
+  vscode-jsonrpc@8.2.0: {}
+
+  vscode-languageserver-protocol@3.17.5:
+    dependencies:
+      vscode-jsonrpc: 8.2.0
+      vscode-languageserver-types: 3.17.5
+
+  vscode-languageserver-textdocument@1.0.12: {}
+
+  vscode-languageserver-types@3.17.5: {}
+
+  vscode-languageserver@9.0.1:
+    dependencies:
+      vscode-languageserver-protocol: 3.17.5
+
+  vscode-uri@3.1.0: {}
+
+  which-module@2.0.1: {}
+
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrappy@1.0.2: {}
+
+  xml2js@0.5.0:
+    dependencies:
+      sax: 1.6.0
+      xmlbuilder: 11.0.1
+
+  xmlbuilder@11.0.1: {}
+
+  y18n@4.0.3: {}
+
+  y18n@5.0.8: {}
+
   yallist@4.0.0: {}
+
+  yargs-parser@18.1.3:
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
+
+  yargs-parser@20.2.9: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@15.4.1:
+    dependencies:
+      cliui: 6.0.0
+      decamelize: 1.2.0
+      find-up: 4.1.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      require-main-filename: 2.0.0
+      set-blocking: 2.0.0
+      string-width: 4.2.3
+      which-module: 2.0.1
+      y18n: 4.0.3
+      yargs-parser: 18.1.3
+
+  yargs@16.2.0:
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.9
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1

--- a/scripts/roku-live-test.ts
+++ b/scripts/roku-live-test.ts
@@ -1,0 +1,287 @@
+#!/usr/bin/env node
+import process from "node:process";
+
+const ecpPort = 8060;
+const requestTimeoutMs = 10_000;
+const launchTimeoutMs = 10_000;
+
+const remoteKeys = [
+  "Home",
+  "Rev",
+  "Fwd",
+  "Play",
+  "Select",
+  "Left",
+  "Right",
+  "Down",
+  "Up",
+  "Back",
+  "InstantReplay",
+  "Info",
+  "Backspace",
+  "Search",
+  "Enter",
+  "VolumeDown",
+  "VolumeMute",
+  "VolumeUp",
+  "PowerOff",
+  "ChannelUp",
+  "ChannelDown",
+  "InputTuner",
+  "InputHDMI1",
+  "InputHDMI2",
+  "InputHDMI3",
+  "InputHDMI4",
+] as const;
+
+type RemoteKey = (typeof remoteKeys)[number] | `Lit_${string}`;
+
+type ActiveApp = {
+  id: string;
+  name: string;
+  type: string;
+  version: string;
+};
+
+function usage(): never {
+  console.error(`usage:
+  node scripts/roku-live-test.ts check
+  node scripts/roku-live-test.ts active-app
+  node scripts/roku-live-test.ts launch [app-id]
+  node scripts/roku-live-test.ts launch-deeplink <content-id> [media-type]
+  node scripts/roku-live-test.ts press <key> [key...]
+  node scripts/roku-live-test.ts control-smoke
+
+environment:
+  ROKU_DEV_TARGET=<roku-ip>`);
+  process.exit(1);
+}
+
+function requireTarget(): string {
+  const rawTarget = process.env.ROKU_DEV_TARGET?.trim();
+
+  if (!rawTarget) {
+    throw new Error("ROKU_DEV_TARGET is not set");
+  }
+
+  return rawTarget
+    .replace(/^https?:\/\//, "")
+    .replace(/\/.*$/, "")
+    .replace(/:\d+$/, "");
+}
+
+function ecpUrl(target: string, path: string): URL {
+  return new URL(path, `http://${target}:${ecpPort}`);
+}
+
+function installerUrl(target: string): URL {
+  return new URL("/", `http://${target}`);
+}
+
+async function fetchText(url: URL, method = "GET"): Promise<string> {
+  const response = await fetch(url, {
+    method,
+    signal: AbortSignal.timeout(requestTimeoutMs),
+  });
+
+  if (!response.ok) {
+    throw new Error(`${method} ${url.href} returned HTTP ${response.status}`);
+  }
+
+  return await response.text();
+}
+
+async function postOk(url: URL): Promise<void> {
+  const response = await fetch(url, {
+    method: "POST",
+    signal: AbortSignal.timeout(requestTimeoutMs),
+  });
+
+  if (!response.ok) {
+    throw new Error(`POST ${url.href} returned HTTP ${response.status}`);
+  }
+}
+
+async function fetchInstallerStatus(target: string): Promise<number> {
+  const response = await fetch(installerUrl(target), {
+    signal: AbortSignal.timeout(requestTimeoutMs),
+  });
+
+  return response.status;
+}
+
+function readXmlTag(xml: string, tag: string): string | undefined {
+  const pattern = new RegExp(`<${tag}>([^<]*)</${tag}>`);
+  return pattern.exec(xml)?.[1]?.trim();
+}
+
+function readActiveApp(xml: string): ActiveApp {
+  const match = /<app\s+([^>]*)>([^<]*)<\/app>/.exec(xml);
+
+  if (!match) {
+    throw new Error("active app response did not include an app node");
+  }
+
+  const attributes = match[1] ?? "";
+
+  return {
+    id: readXmlAttribute(attributes, "id") ?? "",
+    name: match[2]?.trim() ?? "",
+    type: readXmlAttribute(attributes, "type") ?? "",
+    version: readXmlAttribute(attributes, "version") ?? "",
+  };
+}
+
+function readXmlAttribute(attributes: string, name: string): string | undefined {
+  const pattern = new RegExp(`${name}="([^"]*)"`);
+  return pattern.exec(attributes)?.[1];
+}
+
+async function checkDevice(target: string): Promise<void> {
+  const deviceInfo = await fetchText(ecpUrl(target, "/query/device-info"));
+  const name =
+    readXmlTag(deviceInfo, "friendly-device-name") ??
+    readXmlTag(deviceInfo, "friendlyName") ??
+    "unknown";
+  const model = readXmlTag(deviceInfo, "model-name") ?? "unknown model";
+  const installerStatus = await fetchInstallerStatus(target);
+
+  console.log(`device: ${name} (${model})`);
+  console.log(`ecp: http://${target}:${ecpPort}`);
+  console.log(`developer installer HTTP status: ${installerStatus}`);
+}
+
+async function queryActiveApp(target: string): Promise<ActiveApp> {
+  const xml = await fetchText(ecpUrl(target, "/query/active-app"));
+  return readActiveApp(xml);
+}
+
+async function printActiveApp(target: string): Promise<void> {
+  const app = await queryActiveApp(target);
+  console.log(`active app: ${app.id} ${app.name} ${app.version}`.trim());
+}
+
+async function launchApp(target: string, appId: string): Promise<ActiveApp> {
+  await postOk(ecpUrl(target, `/launch/${encodeURIComponent(appId)}`));
+  return await waitForActiveApp(target, appId);
+}
+
+async function launchDeepLink(
+  target: string,
+  contentId: string,
+  mediaType: string,
+): Promise<ActiveApp> {
+  const url = ecpUrl(target, "/launch/dev");
+  url.searchParams.set("contentID", contentId);
+  url.searchParams.set("mediaType", mediaType);
+
+  await postOk(url);
+  return await waitForActiveApp(target, "dev");
+}
+
+async function waitForActiveApp(
+  target: string,
+  appId: string,
+): Promise<ActiveApp> {
+  const start = Date.now();
+  let lastApp: ActiveApp | undefined;
+
+  while (Date.now() - start < launchTimeoutMs) {
+    lastApp = await queryActiveApp(target);
+
+    if (lastApp.id === appId) {
+      return lastApp;
+    }
+
+    await sleep(500);
+  }
+
+  const last = lastApp ? `${lastApp.id} ${lastApp.name}` : "unknown";
+  throw new Error(`expected active app ${appId}, got ${last}`);
+}
+
+async function pressKey(target: string, key: string): Promise<void> {
+  assertRemoteKey(key);
+  await postOk(ecpUrl(target, `/keypress/${encodeURIComponent(key)}`));
+  console.log(`pressed: ${key}`);
+}
+
+function assertRemoteKey(key: string): asserts key is RemoteKey {
+  if (key.startsWith("Lit_")) {
+    return;
+  }
+
+  if (!remoteKeys.includes(key as (typeof remoteKeys)[number])) {
+    throw new Error(`unsupported remote key: ${key}`);
+  }
+}
+
+async function controlSmoke(target: string): Promise<void> {
+  await checkDevice(target);
+  const launchedApp = await launchApp(target, "dev");
+  console.log(
+    `launched: ${launchedApp.id} ${launchedApp.name} ${launchedApp.version}`,
+  );
+
+  await pressKey(target, "Info");
+  await sleep(300);
+  await pressKey(target, "Back");
+
+  const activeApp = await waitForActiveApp(target, "dev");
+  console.log(`asserted active dev app: ${activeApp.name} ${activeApp.version}`);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function main(): Promise<void> {
+  const target = requireTarget();
+  const [command, ...args] = process.argv.slice(2);
+
+  if (!command) {
+    usage();
+  }
+
+  if (command === "check") {
+    await checkDevice(target);
+  } else if (command === "active-app") {
+    await printActiveApp(target);
+  } else if (command === "launch") {
+    const appId = args[0] ?? "dev";
+    const app = await launchApp(target, appId);
+    console.log(`launched: ${app.id} ${app.name} ${app.version}`.trim());
+  } else if (command === "launch-deeplink") {
+    const [contentId, mediaType = "movie"] = args;
+
+    if (!contentId) {
+      usage();
+    }
+
+    const app = await launchDeepLink(target, contentId, mediaType);
+    console.log(
+      `launched deeplink: ${app.id} ${app.name} ${app.version} contentID=${contentId} mediaType=${mediaType}`.trim(),
+    );
+  } else if (command === "press") {
+    if (args.length === 0) {
+      usage();
+    }
+
+    for (const key of args) {
+      await pressKey(target, key);
+      await sleep(250);
+    }
+  } else if (command === "control-smoke") {
+    await controlSmoke(target);
+  } else {
+    usage();
+  }
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`ERROR: ${message}`);
+  process.exit(1);
+});

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -1,41 +1,51 @@
-sub Main()
-  screen = CreateObject("roSGScreen")
-  m.port = CreateObject("roMessagePort")
-  screen.setMessagePort(m.port)
+sub Main(args as object)
+    screen = CreateObject("roSGScreen")
+    m.port = CreateObject("roMessagePort")
+    screen.setMessagePort(m.port)
 
-  m.global = screen.getGlobalNode()
-  m.global.addFields({
-    appId: "3776",
-    user: {},
-    route: {
-      id: "splashScreen",
-      params: {},
-    },
-    apiURL: "https://api.put.io/v2",
-  })
+    m.global = screen.getGlobalNode()
+    m.global.addFields({
+        appId: "3776",
+        user: {},
+        route: {
+            id: "splashScreen",
+            params: {},
+        },
+        apiURL: "https://api.put.io/v2",
+    })
 
-  scene = screen.CreateScene("App")
-  scene.backgroundColor="0x333333FF"
-  scene.backgroundUri = ""
-
-  screen.show()
-
-  scene.signalBeacon("AppLaunchComplete")
-  scene.observeField("exitApp", m.port)
-
-  while(true)
-    msg = wait(0, m.port)
-    msgType = type(msg)
-
-    if msgType = "roSGScreenEvent" then
-      if msg.isScreenClosed() then
-        return
-      end if
-    else if msgType = "roSGNodeEvent" then
-      field = msg.getField()
-      if field = "exitApp" then
-        return
-      end if
+    scene = screen.CreateScene("App")
+    scene.backgroundColor = "0x333333FF"
+    scene.backgroundUri = ""
+    if args <> invalid
+        scene.deepLink = args
     end if
-  end while
+
+    input = CreateObject("roInput")
+    input.setMessagePort(m.port)
+
+    screen.show()
+
+    scene.signalBeacon("AppLaunchComplete")
+    scene.observeField("exitApp", m.port)
+
+    while(true)
+        msg = wait(0, m.port)
+        msgType = type(msg)
+
+        if msgType = "roSGScreenEvent" then
+            if msg.isScreenClosed() then
+                return
+            end if
+        else if msgType = "roInputEvent" then
+            if msg.isInput()
+                scene.deepLink = msg.getInfo()
+            end if
+        else if msgType = "roSGNodeEvent" then
+            field = msg.getField()
+            if field = "exitApp" then
+                return
+            end if
+        end if
+    end while
 end sub


### PR DESCRIPTION
## Summary

Add modern Roku verification tooling, headless live-device controls, and video deep-link support for put.io file playback.

## Changed

- Simplified the Makefile around deterministic ZIP builds, static checks, sideload install, ECP launch, console, and live-test targets.
- Added BrighterScript/bslint config plus CI/release workflow dependency setup.
- Added a typed `scripts/roku-live-test.ts` ECP helper for device checks, remote keypresses, control smoke tests, and `contentID`/`mediaType` deep-link launches.
- Wired Roku launch/input args into the app router so video deep links open `VideoScreen` and Back returns to Home.
- Documented the live hardware debugging flow without checked-in private device details.
- Applied repo-wide `bsfmt` formatting.

## Risks

- Makefile simplification removes older unused packaging/native helper targets; reviewers should confirm no external automation still calls those removed targets.
- Deep-link behavior is scoped to video file ids; folder/search deep links are intentionally out of scope.

## Verification

- `pnpm format:roku`
- `make verify`
- `git diff --check origin/main...HEAD`
- Live Roku proof: installed the dev ZIP, launched `make live-test-deeplink CONTENT_ID=<file-id>`, observed `VideoScreen`, subtitle rows, and playback with SRT captions through Roku WebDriver.

## Complexity

Neutral. The build path is smaller, while the new live-test helper gives agents and humans a deterministic route into hardware checks.