### PR TITLE
fix(secrets): handle Infisical dotenv suffix

### DIFF
--- a/scripts/roku-task/secrets.ts
+++ b/scripts/roku-task/secrets.ts
@@ -60,7 +60,7 @@ export function resolveSecretExportFile(requestedPath: string): string {
 
   const source = candidates[0];
   if (source === undefined || !lstatSync(source).isFile()) {
-    throw new Error("Infisical export output is not a regular file");
+    throw new Error(`Infisical export output is not a regular file: ${source ?? requestedPath}`);
   }
 
   return source;

--- a/scripts/roku-task/secrets.ts
+++ b/scripts/roku-task/secrets.ts
@@ -1,5 +1,7 @@
 import {
   chmodSync,
+  existsSync,
+  lstatSync,
   mkdtempSync,
   readFileSync,
   readdirSync,
@@ -42,10 +44,26 @@ export function secretsSetup(): void {
       "--output-file",
       tempFile,
     ]);
-    installSecretFile(tempFile, output);
+    installSecretFile(resolveSecretExportFile(tempFile), output);
   } finally {
     rmSync(tempDir, { force: true, recursive: true });
   }
+}
+
+export function resolveSecretExportFile(requestedPath: string): string {
+  const candidates = [requestedPath, `${requestedPath}.env`].filter(existsSync);
+  if (candidates.length !== 1) {
+    throw new Error(
+      `Infisical export wrote ${candidates.length} recognized output files; expected exactly one`,
+    );
+  }
+
+  const source = candidates[0];
+  if (source === undefined || !lstatSync(source).isFile()) {
+    throw new Error("Infisical export output is not a regular file");
+  }
+
+  return source;
 }
 
 export function secretsClean(): void {

--- a/test/live-test/secrets.test.ts
+++ b/test/live-test/secrets.test.ts
@@ -1,0 +1,48 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveSecretExportFile } from "../../scripts/roku-task/secrets.ts";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const tempDir of tempDirs.splice(0)) {
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});
+
+describe("Infisical export output", () => {
+  it("accepts the requested output path", () => {
+    const requestedPath = makeRequestedPath();
+    writeFileSync(requestedPath, "EXAMPLE=value\n");
+
+    expect(resolveSecretExportFile(requestedPath)).toBe(requestedPath);
+  });
+
+  it("accepts the dotenv suffix added by Infisical", () => {
+    const requestedPath = makeRequestedPath();
+    writeFileSync(`${requestedPath}.env`, "EXAMPLE=value\n");
+
+    expect(resolveSecretExportFile(requestedPath)).toBe(`${requestedPath}.env`);
+  });
+
+  it("rejects missing or ambiguous export output", () => {
+    const requestedPath = makeRequestedPath();
+    expect(() => resolveSecretExportFile(requestedPath)).toThrow(
+      "Infisical export wrote 0 recognized output files",
+    );
+
+    writeFileSync(requestedPath, "FIRST=value\n");
+    writeFileSync(`${requestedPath}.env`, "SECOND=value\n");
+    expect(() => resolveSecretExportFile(requestedPath)).toThrow(
+      "Infisical export wrote 2 recognized output files",
+    );
+  });
+});
+
+function makeRequestedPath(): string {
+  const tempDir = mkdtempSync(join(tmpdir(), "putio-roku-secrets-test-"));
+  tempDirs.push(tempDir);
+  return join(tempDir, "env");
+}

--- a/test/live-test/secrets.test.ts
+++ b/test/live-test/secrets.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -37,6 +37,15 @@ describe("Infisical export output", () => {
     writeFileSync(`${requestedPath}.env`, "SECOND=value\n");
     expect(() => resolveSecretExportFile(requestedPath)).toThrow(
       "Infisical export wrote 2 recognized output files",
+    );
+  });
+
+  it("rejects a non-regular export artifact", () => {
+    const requestedPath = makeRequestedPath();
+    mkdirSync(requestedPath);
+
+    expect(() => resolveSecretExportFile(requestedPath)).toThrow(
+      `Infisical export output is not a regular file: ${requestedPath}`,
     );
   });
 });


### PR DESCRIPTION
## Summary

Make `secrets-setup` compatible with Infisical CLI versions that append `.env` to dotenv export paths.

## Changed

- resolve either the exact temporary export path or Infisical's `.env`-suffixed path
- reject missing, ambiguous, or non-regular export artifacts
- add regression coverage for suffixed, unsuffixed, and invalid output states

## Risks

Low. Resolution remains limited to two expected files inside the private temporary export directory, and final installation remains atomic with mode `0600`.

## Verification

- repository verify gate: TypeScript, 37 tests, formatting, BrightScript checks, visual manifest, production package
- real Infisical export produced the suffixed artifact, installed a non-empty temporary target with mode `0600`, and cleaned up afterward

## Complexity

Neutral. One small compatibility resolver replaces an assumption about Infisical's output filename.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make secrets setup compatible with newer `infisical` CLI that appends `.env` to the dotenv export path. Resolves the correct export file and fails fast on missing, ambiguous, or non-regular outputs.

- **Bug Fixes**
  - Accept either the requested export path or `<path>.env` from `infisical`.
  - Error on missing, multiple, or non-file outputs (e.g., directory).
  - Add tests for suffixed, unsuffixed, missing/ambiguous, and non-regular cases.

<sup>Written for commit c2a11b326d030cececf5949ff6be43b2c26c5274. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/putdotio/putio-roku/pull/36?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

