### PR TITLE
feat(vref): publish the visual reference at /vref and land the site root there

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,6 +170,9 @@ jobs:
           cp .vref/index.html .vref/manifest.json dist/public/vref/
           cp -R .vref/screenshots dist/public/vref/
 
+          # Root landing: redirect bare domain + unknown paths to the gallery
+          cp infra/site-root/index.html dist/public/index.html
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,6 +165,11 @@ jobs:
           cp "${release_zip}" dist/public/v2.zip
           cp "${release_zip}" "dist/public/releases/v2/${RELEASE_VERSION}.zip"
 
+          # Publish the curated visual reference gallery at /vref
+          mkdir -p dist/public/vref
+          cp .vref/index.html .vref/manifest.json dist/public/vref/
+          cp -R .vref/screenshots dist/public/vref/
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:

--- a/.vref/README.md
+++ b/.vref/README.md
@@ -5,6 +5,10 @@ submission prep, and design comparison. It is intentionally lighter than a
 visual regression suite: raw captures stay in `dist/tmp/`, and only curated
 screenshots with stable names are committed here.
 
+On each release the committed gallery is published to
+`https://<ROKU_DOMAIN>/vref/` (served by the SST site alongside the hosted ZIP),
+so everything here must stay public-safe — see [Rules](#rules).
+
 ## Structure
 
 - `manifest.json` lists the curated screenshots and their capture metadata.

--- a/.vref/README.md
+++ b/.vref/README.md
@@ -9,6 +9,13 @@ On each release the committed gallery is published to
 `https://<ROKU_DOMAIN>/vref/` (served by the SST site alongside the hosted ZIP),
 so everything here must stay public-safe — see [Rules](#rules).
 
+The site retains objects (`purge: false`, so the versioned ZIP archive under
+`releases/` is never deleted). Screenshots use stable names and are overwritten
+in place each release, but a **removed or renamed** screenshot persists at its
+old URL until manually purged from the bucket. Treat the public-safe rule as the
+primary control — not after-the-fact removal (these files are already permanent
+in public git history regardless).
+
 ## Structure
 
 - `manifest.json` lists the curated screenshots and their capture metadata.

--- a/infra/site-root/index.html
+++ b/infra/site-root/index.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta http-equiv="refresh" content="0; url=/vref/index.html" />
+    <link rel="canonical" href="/vref/index.html" />
+    <title>put.io on Roku</title>
+    <script>
+      location.replace("/vref/index.html");
+    </script>
+    <style>
+      html,
+      body {
+        height: 100%;
+        margin: 0;
+      }
+      body {
+        background: #161616;
+        color: #e8e8e8;
+        font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        display: grid;
+        place-items: center;
+      }
+      a {
+        color: #fdce45;
+      }
+    </style>
+  </head>
+  <body>
+    <p>Redirecting to the <a href="/vref/index.html">put.io Roku visual reference</a>…</p>
+  </body>
+</html>

--- a/infra/site.ts
+++ b/infra/site.ts
@@ -32,11 +32,13 @@ export function createRokuSite() {
           contentType: "application/zip",
         },
         {
-          files: "vref/**/*.html",
+          // Top-level gallery files (index.html, manifest.json); `*` avoids the
+          // `**/` globstar not matching files directly under vref/.
+          files: "vref/*.html",
           cacheControl: "public,max-age=300",
         },
         {
-          files: "vref/**/*.json",
+          files: "vref/*.json",
           cacheControl: "public,max-age=300",
         },
         {

--- a/infra/site.ts
+++ b/infra/site.ts
@@ -5,6 +5,10 @@ import { AWS_WILDCARD_CERT_ARN, ROKU_DOMAIN, putioDns } from "./shared.js";
 export function createRokuSite() {
   return new sst.aws.StaticSite("putio-roku", {
     path: "dist/public",
+    // Serve the redirect landing for the bare domain and for any unknown path,
+    // so visitors reach the visual reference gallery instead of a raw S3 error.
+    indexPage: "index.html",
+    errorPage: "index.html",
     domain: {
       name: ROKU_DOMAIN,
       cert: AWS_WILDCARD_CERT_ARN,
@@ -13,6 +17,10 @@ export function createRokuSite() {
     assets: {
       purge: false,
       fileOptions: [
+        {
+          files: "index.html",
+          cacheControl: "public,max-age=300",
+        },
         {
           files: "v2.zip",
           cacheControl: "public,max-age=300",
@@ -38,7 +46,7 @@ export function createRokuSite() {
       ],
     },
     invalidation: {
-      paths: ["/v2.zip", "/releases/v2/*", "/vref/*"],
+      paths: ["/", "/index.html", "/v2.zip", "/releases/v2/*", "/vref/*"],
       wait: true,
     },
   });

--- a/infra/site.ts
+++ b/infra/site.ts
@@ -23,10 +23,22 @@ export function createRokuSite() {
           cacheControl: "public,max-age=31536000,immutable",
           contentType: "application/zip",
         },
+        {
+          files: "vref/**/*.html",
+          cacheControl: "public,max-age=300",
+        },
+        {
+          files: "vref/**/*.json",
+          cacheControl: "public,max-age=300",
+        },
+        {
+          files: "vref/**/*.jpg",
+          cacheControl: "public,max-age=86400",
+        },
       ],
     },
     invalidation: {
-      paths: ["/v2.zip", "/releases/v2/*"],
+      paths: ["/v2.zip", "/releases/v2/*", "/vref/*"],
       wait: true,
     },
   });

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -2,6 +2,7 @@
 import { spawnSync } from "node:child_process";
 import {
   copyFileSync,
+  cpSync,
   existsSync,
   mkdirSync,
   readFileSync,
@@ -167,6 +168,18 @@ function stageReleaseFiles(): void {
   copyFileSync(sourceZip, "dist/public/v2.zip");
   copyFileSync(sourceZip, `dist/public/releases/v2/${version}.zip`);
   copyFileSync(sourceZip, `dist/release/putio-roku-v${version}.zip`);
+
+  stageVisualReference();
+}
+
+// Publish the curated visual reference gallery alongside the hosted ZIP so it
+// is served at <ROKU_DOMAIN>/vref/. index.html embeds the screenshots by
+// relative path, so only it, the manifest, and screenshots/ are needed.
+function stageVisualReference(): void {
+  mkdirSync("dist/public/vref", { recursive: true });
+  copyFileSync(".vref/index.html", "dist/public/vref/index.html");
+  copyFileSync(".vref/manifest.json", "dist/public/vref/manifest.json");
+  cpSync(".vref/screenshots", "dist/public/vref/screenshots", { recursive: true });
 }
 
 syncVersion();
@@ -176,4 +189,5 @@ stageReleaseFiles();
 console.log(`Prepared Roku release ${version}`);
 console.log("- dist/public/v2.zip");
 console.log(`- dist/public/releases/v2/${version}.zip`);
+console.log("- dist/public/vref/index.html");
 console.log(`- dist/release/putio-roku-v${version}.zip`);

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -173,17 +173,29 @@ function stageReleaseFiles(): void {
 
   // Root landing: redirect the bare domain (and unknown paths, via errorPage) to
   // the visual reference gallery instead of a raw S3 AccessDenied response.
-  copyFileSync("infra/site-root/index.html", "dist/public/index.html");
+  const siteRoot = "infra/site-root/index.html";
+  requireExists(siteRoot, "site root landing");
+  copyFileSync(siteRoot, "dist/public/index.html");
 }
 
 // Publish the curated visual reference gallery alongside the hosted ZIP so it
 // is served at <ROKU_DOMAIN>/vref/. index.html embeds the screenshots by
 // relative path, so only it, the manifest, and screenshots/ are needed.
 function stageVisualReference(): void {
+  requireExists(".vref/index.html", "visual reference gallery");
+  requireExists(".vref/manifest.json", "visual reference manifest");
+  requireExists(".vref/screenshots", "visual reference screenshots");
+
   mkdirSync("dist/public/vref", { recursive: true });
   copyFileSync(".vref/index.html", "dist/public/vref/index.html");
   copyFileSync(".vref/manifest.json", "dist/public/vref/manifest.json");
   cpSync(".vref/screenshots", "dist/public/vref/screenshots", { recursive: true });
+}
+
+function requireExists(path: string, label: string): void {
+  if (!existsSync(path)) {
+    throw new Error(`missing ${label}: ${path}`);
+  }
 }
 
 syncVersion();

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -170,6 +170,10 @@ function stageReleaseFiles(): void {
   copyFileSync(sourceZip, `dist/release/putio-roku-v${version}.zip`);
 
   stageVisualReference();
+
+  // Root landing: redirect the bare domain (and unknown paths, via errorPage) to
+  // the visual reference gallery instead of a raw S3 AccessDenied response.
+  copyFileSync("infra/site-root/index.html", "dist/public/index.html");
 }
 
 // Publish the curated visual reference gallery alongside the hosted ZIP so it
@@ -187,6 +191,7 @@ runArtifact();
 stageReleaseFiles();
 
 console.log(`Prepared Roku release ${version}`);
+console.log("- dist/public/index.html (redirect -> /vref/index.html)");
 console.log("- dist/public/v2.zip");
 console.log(`- dist/public/releases/v2/${version}.zip`);
 console.log("- dist/public/vref/index.html");


### PR DESCRIPTION
## Summary

Turns `roku.put.io` from a bare S3 bucket (root returns raw `AccessDenied` 403) into a
usable surface: publishes the curated visual-reference gallery at **`/vref/`** and points
the **site root + unknown paths** at it — all on the existing SST static site (no new
infra, DNS, or cert).

## What changed

- **Gallery hosting** — stage `.vref/` (`index.html`, `manifest.json`, `screenshots/`)
  into `dist/public/vref/` in both `prepare-release.ts` (local) and the release deploy job.
- **Root landing** — `infra/site-root/index.html` redirects to `/vref/index.html`; wired as
  the SST `indexPage` **and** `errorPage`, so both `/` and 404s reach the gallery instead of
  the S3 error. Target is `/vref/index.html` (a guaranteed object) — no trailing-slash
  dependency and no error-page redirect loop.
- **`infra/site.ts`** — cache headers for the root + vref assets (`vref/*.html`/`*.json`
  short, `vref/**/*.jpg` a day) and `/`, `/index.html`, `/vref/*` CDN invalidations.

## Behavior

- Refreshes on each release deploy, so the public gallery tracks the shipped build.
- Gallery is self-contained (screenshots by relative path; no runtime fetch / external assets).

## Public-safe note

The repo is already public, so these screenshots are already in public git — this just makes
them browsable. The `.vref` rules already require synthetic/test-account content (no
IPs/tokens/passwords); worth a conscious nod since it's now a discoverable page.

## Verification

- `pnpm verify` green (typechecks `prepare-release.ts`).
- Deploy payload verified locally by replaying the copy commands: `dist/public/index.html`
  (redirect) + `dist/public/vref/{index.html,manifest.json,screenshots/*.jpg}` (19).
- Live `roku.put.io` behavior lands on the next release deploy (the production SST deploy is
  AWS/OIDC-gated and can't run from a PR).

## Review feedback addressed

- Cursor Bugbot: top-level `vref/index.html`/`manifest.json` were missed by the `vref/**/*`
  globs → switched to `vref/*.html`/`vref/*.json`.
- Copilot: `stageVisualReference()` + site-root copy now do explicit existence checks
  (`requireExists`) instead of a low-level ENOENT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static hosting and deploy-pipeline changes only; main caveat is making committed screenshots more discoverable, which the README already frames as a public-safe content requirement.
> 
> **Overview**
> **Publishes the curated `.vref` gallery** on the existing Roku static site at `/vref/` and **replaces the bare-domain S3 403** with a redirect to that gallery.
> 
> Release staging now copies `.vref/index.html`, `manifest.json`, and `screenshots/` into `dist/public/vref/` in both **`scripts/prepare-release.ts`** and the **release deploy workflow**, with **`requireExists`** guards so missing gallery assets fail fast. **`infra/site-root/index.html`** is copied to **`dist/public/index.html`** to send `/` (and unknown paths via SST **`errorPage`**) to `/vref/index.html`.
> 
> **`infra/site.ts`** sets **`indexPage`** / **`errorPage`** to that landing page, adds short-lived cache headers for root and top-level vref HTML/JSON (using `vref/*.html` / `vref/*.json` globs), day-long cache for vref JPGs, and expands CDN invalidation to `/`, `/index.html`, and `/vref/*`. **`.vref/README.md`** documents public URL behavior and public-safe content expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f580e29248e1dddd64c551f9ca85b55fea06f18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->