### PR TITLE
fix(vref): render the gallery at /vref (inject base href)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,9 +165,12 @@ jobs:
           cp "${release_zip}" dist/public/v2.zip
           cp "${release_zip}" "dist/public/releases/v2/${RELEASE_VERSION}.zip"
 
-          # Publish the curated visual reference gallery at /vref
+          # Publish the curated visual reference gallery at /vref. Inject
+          # <base href="/vref/"> so the gallery's relative asset paths resolve
+          # whether it is served at /vref, /vref/, or /vref/index.html.
           mkdir -p dist/public/vref
-          cp .vref/index.html .vref/manifest.json dist/public/vref/
+          sed 's#<head>#<head><base href="/vref/">#' .vref/index.html > dist/public/vref/index.html
+          cp .vref/manifest.json dist/public/vref/
           cp -R .vref/screenshots dist/public/vref/
 
           # Root landing: redirect bare domain + unknown paths to the gallery

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -187,7 +187,16 @@ function stageVisualReference(): void {
   requireExists(".vref/screenshots", "visual reference screenshots");
 
   mkdirSync("dist/public/vref", { recursive: true });
-  copyFileSync(".vref/index.html", "dist/public/vref/index.html");
+  // Inject <base href="/vref/"> so the gallery's relative asset paths resolve
+  // whether the page is served at /vref, /vref/, or /vref/index.html. (The site
+  // serves the gallery at the bare /vref URL, where relative paths would
+  // otherwise resolve against the domain root.) The committed .vref/index.html
+  // stays relative so `vref serve` works locally at the root.
+  const gallery = readFileSync(".vref/index.html", "utf8").replace(
+    /<head>/i,
+    '<head>\n<base href="/vref/">',
+  );
+  writeFileSync("dist/public/vref/index.html", gallery);
   copyFileSync(".vref/manifest.json", "dist/public/vref/manifest.json");
   cpSync(".vref/screenshots", "dist/public/vref/screenshots", { recursive: true });
 }


### PR DESCRIPTION
## Problem

`roku.put.io/vref` (bare, no trailing slash) loaded the gallery HTML but **no images rendered**. The SST site serves `/vref/index.html` at the bare `/vref` URL (200, no redirect), and the generated gallery references assets with **relative** paths (`screenshots/roku-720p/*.jpg`, and the `<a>` card links). At URL `/vref`, the browser resolves those against the domain root → `/screenshots/...` → 404.

## Fix

Inject `<base href="/vref/">` into the **deployed** copy of the gallery `index.html` (in `prepare-release.ts` and the release deploy job), so every relative path resolves under `/vref/` regardless of whether the page is served at `/vref`, `/vref/`, or `/vref/index.html`. The committed `.vref/index.html` stays relative so local `vref serve` (served at the root) still works.

## Verification

Served the base-injected gallery locally and loaded bare `/vref` in a browser:
- all 19 screenshots render;
- image requests resolve to `http://.../vref/screenshots/roku-720p/*.jpg` → **200** (not `/screenshots/...`).

`pnpm verify` green (typechecks `prepare-release.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-time HTML transformation only; no auth, data, or app runtime changes.
> 
> **Overview**
> Fixes broken screenshot rendering when the visual reference gallery is served at the bare **`/vref`** URL (no trailing slash), where relative asset paths were resolving to the site root instead of **`/vref/`**.
> 
> **Deployed** copies of `.vref/index.html` now get `<base href="/vref/">` injected immediately after `<head>` in both **`scripts/prepare-release.ts`** (`stageVisualReference`) and the **release deploy** job in **`.github/workflows/release.yml`** (via `sed`). Manifest and screenshots are still copied unchanged. The committed gallery HTML stays relative so local **`vref serve`** at the root is unaffected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 249f6cbae5108991d2b48d9076f74e2d36240ea2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the visual reference gallery at /vref by injecting a base URL so relative assets resolve under /vref. Screenshots now load at /vref, /vref/, and /vref/index.html.

- **Bug Fixes**
  - Injected `<base href="/vref/">` into the deployed gallery `index.html` in `scripts/prepare-release.ts` and the release workflow.
  - Kept `.vref/index.html` relative for local `vref serve`.
  - Verified locally: images load from `/vref/screenshots/...` (200); `pnpm verify` passes.

<sup>Written for commit 249f6cbae5108991d2b48d9076f74e2d36240ea2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/putdotio/putio-roku/pull/41?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

