### PR TITLE
fix(ci): attach release ZIP via gh CLI to stop flaky deploys

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,30 @@ jobs:
           GIT_COMMITTER_NAME: ${{ steps.release-bot.outputs.app-slug }}[bot]
           GIT_COMMITTER_EMAIL: ${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com
 
+      # Attach the sideload ZIP with the gh CLI instead of @semantic-release/github's
+      # octokit uploader, which intermittently fails on large assets with
+      # "invalid content-length header" (undici) and blocks the deploy. prepareCmd
+      # (scripts/prepare-release.ts) built dist/release/*.zip earlier in this job.
+      - name: Attach sideload ZIP to the release
+        if: steps.semantic.outputs.new_release_published == 'true'
+        env:
+          GH_TOKEN: ${{ steps.release-bot.outputs.token }}
+          RELEASE_VERSION: ${{ steps.semantic.outputs.new_release_version }}
+        run: |
+          set -euo pipefail
+          zip="dist/release/putio-roku-v${RELEASE_VERSION}.zip"
+          test -f "$zip"
+          for attempt in 1 2 3; do
+            if gh release upload "v${RELEASE_VERSION}" "$zip" --clobber; then
+              echo "attached $zip to v${RELEASE_VERSION}"
+              exit 0
+            fi
+            echo "upload attempt ${attempt} failed; retrying in 5s..." >&2
+            sleep 5
+          done
+          echo "::error::failed to attach ${zip} after 3 attempts" >&2
+          exit 1
+
   deploy:
     if: ${{ needs.release.outputs.new_release_published == 'true' }}
     name: Deploy released ZIP

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -27,16 +27,6 @@
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ],
-    [
-      "@semantic-release/github",
-      {
-        "assets": [
-          {
-            "path": "dist/release/*.zip",
-            "label": "put.io Roku sideload ZIP"
-          }
-        ]
-      }
-    ]
+    "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
## Problem

The release deploy has now been skipped **twice** (2.11.2, 2.13.1) by the same transient failure: `@semantic-release/github` uploads the sideload ZIP through octokit/undici, which intermittently rejects the ~600 KB asset with:

```
HttpError: invalid content-length header   (UND_ERR_INVALID_ARG)
```

When that upload fails, the **release job fails → the deploy job (needs: release) is skipped**, so a version that was already tagged never reaches `roku.put.io`. Most recently this left the `/vref` base-href fix (`2.13.1`) undeployed.

## Fix

Move the asset attachment off the flaky octokit path:

- **`.releaserc.json`** — drop `assets` from `@semantic-release/github` (it still creates the release + notes, just no upload).
- **`release.yml`** — add a dedicated release step that attaches the ZIP with the **`gh` CLI** (`gh release upload --clobber`, Go HTTP client — not undici), with 3 retries. `prepareCmd` already built `dist/release/*.zip` earlier in the job.

The deploy job is unchanged — it still `gh release download`s the asset, which is now attached reliably.

## Why this works

The failure is specific to octokit/undici's content-length handling on large uploads (it succeeded on 2.12.0/2.13.0, failed on 2.11.2/2.13.1). The `gh` CLI uses a different HTTP stack with no such issue, and battle-tested large-asset uploads.

## Verification

- `.releaserc.json` valid JSON; `release.yml` valid YAML (release job gains the "Attach sideload ZIP to the release" step).
- `pnpm verify` green.
- End-to-end proof is the next release: merging this cuts `2.13.2`, which should attach the ZIP cleanly and **deploy** — bringing the still-pending `/vref` base-href fix live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to how the release artifact is attached; deploy path and artifact naming stay the same, with retries improving reliability.
> 
> **Overview**
> **Fixes intermittent release job failures** that blocked production deploy when `@semantic-release/github` uploaded the sideload ZIP via octokit/undici (`invalid content-length header`).
> 
> **`.releaserc.json`** — `@semantic-release/github` no longer declares `assets`; it still creates the GitHub release and notes only.
> 
> **`release.yml`** — After semantic-release, when a new version is published, a step uploads `dist/release/putio-roku-v${RELEASE_VERSION}.zip` with `gh release upload … --clobber`, up to three attempts with a 5s backoff. The deploy job is unchanged and still downloads that asset from the release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f050bc0127010e73241af5d3e026ef2093082be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch release asset upload to `gh` CLI to stop flaky `@semantic-release/github`/octokit uploads that sometimes failed and skipped deploys. This makes attaching the ZIP reliable so the deploy job runs.

- **Bug Fixes**
  - Dropped `assets` from `@semantic-release/github` in `.releaserc.json` (it still creates the release and notes).
  - Added a release step in `release.yml` to upload `dist/release/*.zip` via `gh release upload --clobber` with 3 retries.
  - Deploy job is unchanged and continues to `gh release download` the asset.

<sup>Written for commit 3f050bc0127010e73241af5d3e026ef2093082be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/putdotio/putio-roku/pull/42?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

