### PR TITLE
chore(deps): allow first-party @putdotio publishes and bump rokit to 2.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@phosphor-icons/core": "2.1.1",
     "@putdotio/design": "^1.4.0",
-    "@putdotio/rokit": "2.4.1",
+    "@putdotio/rokit": "2.4.2",
     "@putdotio/vref": "1.1.0",
     "@resvg/resvg-js": "^2.6.2",
     "@rokucommunity/bslint": "0.8.44",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0
       '@putdotio/rokit':
-        specifier: 2.4.1
-        version: 2.4.1(ioredis@5.10.1)
+        specifier: 2.4.2
+        version: 2.4.2(ioredis@5.10.1)
       '@putdotio/vref':
         specifier: 1.1.0
         version: 1.1.0
@@ -211,8 +211,8 @@ packages:
   '@putdotio/design@1.4.0':
     resolution: {integrity: sha512-NdW4esNv/set4UAs0VX/KfXbFuqGZdyNb5deGViaNK/SXc/2vv4tHCuofzms73TAp7zTwmI/yVgm1VnDamWU7A==}
 
-  '@putdotio/rokit@2.4.1':
-    resolution: {integrity: sha512-DNAmOpZViN5kzJwkpmi/DW5xyTCFhUQKn5jQgRZeu/1gKcml67Htx4hiSIKLhufU9ZgAwUgPTTA2HSsdR0jYyA==}
+  '@putdotio/rokit@2.4.2':
+    resolution: {integrity: sha512-GVSiqnrAezbWxSQnlSMv/7byLTowcowLw0L5gltsGSWNo65t0EJW8GQ9iMq7hE+x6bXgNEMKbp03c5l47j4czA==}
     engines: {node: '>=24.18.0'}
     hasBin: true
 
@@ -2055,7 +2055,7 @@ snapshots:
 
   '@putdotio/design@1.4.0': {}
 
-  '@putdotio/rokit@2.4.1(ioredis@5.10.1)':
+  '@putdotio/rokit@2.4.2(ioredis@5.10.1)':
     dependencies:
       '@effect/platform-node': 4.0.0-beta.97(effect@4.0.0-beta.97)(ioredis@5.10.1)
       effect: 4.0.0-beta.97

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 allowBuilds:
   msgpackr-extract: true
 minimumReleaseAgeExclude:
-  - '@putdotio/rokit@2.4.0'
-  - '@putdotio/design@1.4.0'
+  # First-party packages are trusted (we publish them), so exempt the whole
+  # scope from the minimum-release-age policy that guards third-party publishes.
+  - '@putdotio/*'


### PR DESCRIPTION
## Summary

Bumps `@putdotio/rokit` to **2.4.2** (putdotio/rokit#51 — empty-slot delete fix, so `pnpm sideload` onto an empty developer slot works on older devices), and switches the `minimumReleaseAge` exclude to the whole first-party scope.

## Why the scope glob

The per-version entries (`@putdotio/rokit@2.4.0`, `@putdotio/design@1.4.0`) are `name@version`, which pnpm's **lockfile** supply-chain verification does not treat as a name pattern — so a freshly published first-party version stays blocked by the 24h minimum-release-age policy (this is exactly what blocked the `2.4.2` bump). Replacing them with `@putdotio/*` exempts the trusted first-party scope from a policy meant to guard *third-party* publishes, and pnpm no longer needs to append per-version "immature" entries.

## Scope

Dev-tooling only — `@putdotio/rokit` is used by `scripts/` for device control, not bundled in the Roku app. No app change, so no release/deploy (`chore(deps)`).

## Verification

- `pnpm add @putdotio/rokit@2.4.2` now passes the lockfile supply-chain check (`✓ Lockfile passes supply-chain policies`) with the scope glob.
- `pnpm verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and pnpm policy-only changes to dev tooling; no app runtime or security-sensitive logic touched.
> 
> **Overview**
> Bumps **`@putdotio/rokit`** from `2.4.1` to **`2.4.2`** (includes a fix for deleting empty developer slots so **`pnpm sideload`** works on older devices). Lockfile updates follow the version pin.
> 
> **pnpm** supply-chain policy is adjusted: **`minimumReleaseAgeExclude`** drops per-version entries (`@putdotio/rokit@2.4.0`, `@putdotio/design@1.4.0`) in favor of **`@putdotio/*`**, so newly published first-party packages are not blocked by the 24h minimum-release-age rule meant for third-party deps.
> 
> Scope is **dev tooling only** — rokit drives `scripts/` device/sideload flows, not the shipped Roku app.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 548b617ed0f3dc4342efe37270a61492e8bd98c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow first-party `@putdotio/*` packages to bypass the 24h minimum-release-age policy so fresh internal publishes pass lockfile supply-chain checks. Bump `@putdotio/rokit` to 2.4.2, fixing empty-slot delete so `pnpm sideload` works on older devices; dev tooling only, no app changes.

<sup>Written for commit 548b617ed0f3dc4342efe37270a61492e8bd98c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/putdotio/putio-roku/pull/43?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

