### PR TITLE
feat(secrets): adopt SOPS live-test payload

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,8 @@
 # Optional local overrides for sideloading and packaging.
 # Build-only commands such as `pnpm verify` do not require this file.
-# Put.io team members can render shared Infisical-backed live-test values with:
-#   pnpm roku secrets-setup
-# The generated .env.local is ignored by git and should keep local device values.
+# Maintainers can render an authorized SOPS live-test payload with:
+#   PUTIO_ROKU_SOPS_FILE=/path/to/roku.sops.env pnpm roku secrets-setup
+# The generated .env.local is ignored; keep the local device target in this file.
 
 ROKU_DEV_TARGET="192.168.0.10"
 ROKU_DEV_PASSWORD=""

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@
 
 `.worktreeinclude` carries `.env` files into Codex and Claude worktrees. Run
 `pnpm install --frozen-lockfile`; use `pnpm roku secrets-setup` if they are
-missing or stale.
+missing or stale and a maintainer supplied a SOPS payload.
 
 ## Rules
 
@@ -56,7 +56,7 @@ missing or stale.
 ## Build And Config
 
 - Local overrides flow through optional `.env` and ignored `.env.local`; `.env.local` wins when both are present
-- `pnpm roku secrets-setup` writes shared test-account, OAuth, and fixture values from maintainer-supplied `PUTIO_ROKU_INFISICAL_*` values; local Roku device values still belong in `.env.local`
+- `PUTIO_ROKU_SOPS_FILE=/path/to/roku.sops.env pnpm roku secrets-setup` decrypts a maintainer-supplied SOPS payload into ignored mode-`0600` `.env.local`; keep the local Roku target in `.env`
 - `.env.example` must stay sanitized and safe to publish
 - `pnpm verify` type-checks the live-test harness, checks Roku formatting, runs Roku static checks, and builds a fresh ZIP
 - `pnpm roku test-live` runs the Vitest contract tests for live-test flow wiring, fixture argument parsing, and Lab visual-capture registry drift

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,18 +9,17 @@ Prerequisites:
 - Node.js from `.node-version`
 - `pnpm`
 
-Optional local overrides live in `.env` or `.env.local`. If your onboarding
-includes Infisical access, render the shared testing-account values first:
+Optional local overrides live in `.env` or `.env.local`. If a maintainer gave
+you access to the shared encrypted test payload, render it first:
 
 ```bash
-pnpm roku secrets-setup
+PUTIO_ROKU_SOPS_FILE=/path/to/roku.sops.env pnpm roku secrets-setup
 ```
 
-That reads the repo-owned Infisical path and writes an ignored `.env.local` with
-the shared put.io test account, OAuth fields, and live-test fixture IDs. Set the
-onboarding-provided `PUTIO_ROKU_INFISICAL_*` variables in this repo or worktree
-shell before running the command. Keep using that same account for
-hardware-backed Roku checks so
+That decrypts the SOPS payload and atomically writes an ignored mode-`0600`
+`.env.local` with the shared put.io test account, OAuth fields, Roku Developer
+Mode password, and live-test fixture IDs. SOPS must be able to discover your
+authorized age identity. Keep using that same account for hardware-backed Roku checks so
 screenshots, file navigation, playback, and track-selection flows exercise
 stable fixtures.
 
@@ -30,8 +29,9 @@ If you are using your own local device or credentials, copy the sample file:
 cp .env.example .env
 ```
 
-Then fill in the device and fixture values you have locally. The Infisical
-setup command is only needed when you are using the shared test fixtures.
+Then fill in the device and fixture values you have locally. Keep the device IP
+in `.env`; rerunning `secrets-setup` replaces `.env.local`. The SOPS setup
+command is only needed when you are using the shared test fixtures.
 
 Supported variables:
 
@@ -39,7 +39,7 @@ Supported variables:
 - `ROKU_DEV_PASSWORD` or `ROKIT_PASSWORD` for the Roku Developer Mode password when authenticated installs are required
 - `ROKU_APP_ECP_ID` for the ECP app id to launch during live tests; defaults to `dev` for sideloaded packages
 - `PLAYBACK_CONTENT_ID`, `IMAGE_CONTENT_ID`, `AUDIO_CONTENT_ID`, and `SUBTITLE_CONTENT_ID` for the full hardware-backed live-test sweep
-- `PUTIO_CLI_PROFILE`, `PUTIO_CLI_CONFIG_PATH`, `PUTIO_TEST_USERNAME`, `PUTIO_TEST_PASSWORD`, `PUTIO_TEST_TOTP_REFERENCE`, `PUTIO_CLIENT_ID_FIRST_PARTY`, and `PUTIO_CLIENT_SECRET_FIRST_PARTY` for the Infisical-backed put.io CLI harness
+- `PUTIO_CLI_PROFILE`, `PUTIO_CLI_CONFIG_PATH`, `PUTIO_TEST_USERNAME`, `PUTIO_TEST_PASSWORD`, `PUTIO_TEST_TOTP_REFERENCE`, `PUTIO_CLIENT_ID_FIRST_PARTY`, and `PUTIO_CLIENT_SECRET_FIRST_PARTY` for the put.io CLI harness
 
 If you need help enabling Developer Mode on the device itself, use the [Sideloading guide](./docs/SIDELOADING.md)
 

--- a/live-test/README.md
+++ b/live-test/README.md
@@ -5,19 +5,18 @@ proof from a real Roku device instead of only a ZIP build.
 
 ## Setup
 
-If your onboarding includes Infisical access, render the shared testing-account
-and fixture values first, then fill in the local device values in the generated
-file:
+If a maintainer gave you access to the shared encrypted test payload, render
+the testing-account and fixture values first:
 
 ```bash
-pnpm roku secrets-setup
+PUTIO_ROKU_SOPS_FILE=/path/to/roku.sops.env pnpm roku secrets-setup
 ```
 
-`pnpm roku secrets-setup` writes `.env.local` from the repo-owned Infisical path.
-Set the onboarding-provided `PUTIO_ROKU_INFISICAL_*` variables in this repo or
-worktree shell before running the command. The generated file includes the
-approved put.io CLI profile, harness credentials, OAuth fields, and the file IDs
-used by `pnpm roku live-test-flow-full`.
+`pnpm roku secrets-setup` decrypts the SOPS payload and atomically writes an
+ignored mode-`0600` `.env.local`. SOPS must be able to discover your authorized
+age identity. The generated file includes the approved put.io CLI profile,
+harness credentials, OAuth fields, Roku Developer Mode password, and the file
+IDs used by `pnpm roku live-test-flow-full`.
 
 If you are using your own local device or credentials, copy the sample
 environment file:
@@ -67,6 +66,9 @@ PUTIO_CLIENT_SECRET_FIRST_PARTY=<oauth-client-secret>
 Keep `.env` and `.env.local` local. Device IPs, Developer Mode passwords,
 signing keys, and download tokens do not belong in git. `.putio-cli/` is ignored
 and may contain local put.io CLI auth state for the testing account.
+
+Keep the device IP in `.env`; rerunning `secrets-setup` replaces `.env.local`.
+The SOPS setup command is only needed when you are using the shared fixtures.
 
 Install the repo toolchain before running smoke or install checks:
 

--- a/scripts/roku-task/secrets.ts
+++ b/scripts/roku-task/secrets.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import {
   chmodSync,
   existsSync,
@@ -10,60 +11,112 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { basename, dirname, join } from "node:path";
+import { basename, dirname, isAbsolute, join, normalize } from "node:path";
 import process from "node:process";
 import { envOr, repoRoot, requireEnv, run } from "./runtime.ts";
 
-export function secretsSetup(): void {
-  const projectId = requireEnv(
-    "PUTIO_ROKU_INFISICAL_PROJECT_ID",
-    "PUTIO_ROKU_INFISICAL_PROJECT_ID=<project-id> PUTIO_ROKU_INFISICAL_PATH=<path> pnpm roku secrets-setup",
-  );
-  const path = requireEnv(
-    "PUTIO_ROKU_INFISICAL_PATH",
-    "PUTIO_ROKU_INFISICAL_PROJECT_ID=<project-id> PUTIO_ROKU_INFISICAL_PATH=<path> pnpm roku secrets-setup",
+const secretKeys = [
+  "AUDIO_CONTENT_ID",
+  "IMAGE_CONTENT_ID",
+  "PLAYBACK_CONTENT_ID",
+  "PUTIO_CLI_CONFIG_PATH",
+  "PUTIO_CLI_PROFILE",
+  "PUTIO_CLIENT_ID_FIRST_PARTY",
+  "PUTIO_CLIENT_SECRET_FIRST_PARTY",
+  "PUTIO_TEST_PASSWORD",
+  "PUTIO_TEST_TOTP_REFERENCE",
+  "PUTIO_TEST_USERNAME",
+  "ROKU_DEV_PASSWORD",
+  "SUBTITLE_CONTENT_ID",
+] as const;
+
+const numericSecretKeys = new Set<string>([
+  "AUDIO_CONTENT_ID",
+  "IMAGE_CONTENT_ID",
+  "PLAYBACK_CONTENT_ID",
+  "PUTIO_CLIENT_ID_FIRST_PARTY",
+  "SUBTITLE_CONTENT_ID",
+]);
+
+export interface RokuSecretPayload {
+  readonly AUDIO_CONTENT_ID: string;
+  readonly IMAGE_CONTENT_ID: string;
+  readonly PLAYBACK_CONTENT_ID: string;
+  readonly PUTIO_CLI_CONFIG_PATH: string;
+  readonly PUTIO_CLI_PROFILE: string;
+  readonly PUTIO_CLIENT_ID_FIRST_PARTY: string;
+  readonly PUTIO_CLIENT_SECRET_FIRST_PARTY: string;
+  readonly PUTIO_TEST_PASSWORD: string;
+  readonly PUTIO_TEST_TOTP_REFERENCE: string;
+  readonly PUTIO_TEST_USERNAME: string;
+  readonly ROKU_DEV_PASSWORD: string;
+  readonly SUBTITLE_CONTENT_ID: string;
+}
+
+type DecryptPayload = (ciphertext: string, output: string) => void;
+
+export function secretsSetup(decryptPayload: DecryptPayload = decryptSopsPayload): void {
+  const ciphertext = requireEnv(
+    "PUTIO_ROKU_SOPS_FILE",
+    "PUTIO_ROKU_SOPS_FILE=/path/to/roku.sops.env pnpm roku secrets-setup",
   );
   const output = envOr("SECRETS_OUTPUT", ".env.local");
+  assertRegularFile(ciphertext, "ciphertext input");
+  assertSafeOutput(output);
+
   const tempDir = mkdtempSync(join(tmpdir(), "putio-roku-secrets-"));
   chmodSync(tempDir, 0o700);
-  const tempFile = join(tempDir, "env");
+  const decryptedFile = join(tempDir, "payload.json");
+  const renderedFile = join(tempDir, "env");
   try {
-    run("infisical", [
-      "export",
-      "--silent",
-      "--domain",
-      envOr("PUTIO_INFISICAL_DOMAIN", "https://eu.infisical.com/api"),
-      "--projectId",
-      projectId,
-      "--env",
-      envOr("PUTIO_ROKU_INFISICAL_ENV", "dev"),
-      "--path",
-      path,
-      "--format",
-      "dotenv",
-      "--output-file",
-      tempFile,
-    ]);
-    installSecretFile(resolveSecretExportFile(tempFile), output);
+    decryptPayload(ciphertext, decryptedFile);
+    assertRegularFile(decryptedFile, "decrypted payload");
+    chmodSync(decryptedFile, 0o600);
+    const payload = parseSecretPayload(readFileSync(decryptedFile, "utf8"));
+    writeFileSync(renderedFile, renderSecretPayload(payload), { flag: "wx", mode: 0o600 });
+    installSecretFile(renderedFile, output);
   } finally {
     rmSync(tempDir, { force: true, recursive: true });
   }
 }
 
-export function resolveSecretExportFile(requestedPath: string): string {
-  const candidates = [requestedPath, `${requestedPath}.env`].filter(existsSync);
-  if (candidates.length !== 1) {
-    throw new Error(
-      `Infisical export wrote ${candidates.length} recognized output files; expected exactly one`,
-    );
+export function parseSecretPayload(serialized: string): RokuSecretPayload {
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(serialized);
+  } catch {
+    throw new Error("Decrypted SOPS payload must be valid JSON");
   }
 
-  const source = candidates[0];
-  if (source === undefined || !lstatSync(source).isFile()) {
-    throw new Error(`Infisical export output is not a regular file: ${source ?? requestedPath}`);
+  if (typeof decoded !== "object" || decoded === null || Array.isArray(decoded)) {
+    throw new Error("Decrypted SOPS payload must be a JSON object");
   }
 
-  return source;
+  const values = new Map(Object.entries(decoded));
+  const actualKeys = [...values.keys()].sort();
+  const expectedKeys = [...secretKeys].sort();
+  if (actualKeys.join("\n") !== expectedKeys.join("\n")) {
+    throw new Error("Decrypted SOPS payload key inventory does not match the Roku contract");
+  }
+
+  return {
+    AUDIO_CONTENT_ID: readSecret(values, "AUDIO_CONTENT_ID"),
+    IMAGE_CONTENT_ID: readSecret(values, "IMAGE_CONTENT_ID"),
+    PLAYBACK_CONTENT_ID: readSecret(values, "PLAYBACK_CONTENT_ID"),
+    PUTIO_CLI_CONFIG_PATH: readSecret(values, "PUTIO_CLI_CONFIG_PATH"),
+    PUTIO_CLI_PROFILE: readSecret(values, "PUTIO_CLI_PROFILE"),
+    PUTIO_CLIENT_ID_FIRST_PARTY: readSecret(values, "PUTIO_CLIENT_ID_FIRST_PARTY"),
+    PUTIO_CLIENT_SECRET_FIRST_PARTY: readSecret(values, "PUTIO_CLIENT_SECRET_FIRST_PARTY"),
+    PUTIO_TEST_PASSWORD: readSecret(values, "PUTIO_TEST_PASSWORD"),
+    PUTIO_TEST_TOTP_REFERENCE: readSecret(values, "PUTIO_TEST_TOTP_REFERENCE"),
+    PUTIO_TEST_USERNAME: readSecret(values, "PUTIO_TEST_USERNAME"),
+    ROKU_DEV_PASSWORD: readSecret(values, "ROKU_DEV_PASSWORD"),
+    SUBTITLE_CONTENT_ID: readSecret(values, "SUBTITLE_CONTENT_ID"),
+  };
+}
+
+export function renderSecretPayload(payload: RokuSecretPayload): string {
+  return `${secretKeys.map((key) => `${key}=${JSON.stringify(payload[key])}`).join("\n")}\n`;
 }
 
 export function secretsClean(): void {
@@ -72,6 +125,78 @@ export function secretsClean(): void {
     if (/^\.env\.local\.(?:.+|swp)$/.test(entry)) {
       rmSync(entry, { force: true });
     }
+  }
+}
+
+function readSecret(values: ReadonlyMap<string, unknown>, key: string): string {
+  const value = values.get(key);
+  if (typeof value !== "string") {
+    throw new Error(`Decrypted SOPS payload value for ${key} must be a string`);
+  }
+  if (value === "") {
+    throw new Error(`Decrypted SOPS payload value for ${key} must not be empty`);
+  }
+  if (/^["'].*["']$/.test(value)) {
+    throw new Error(`Decrypted SOPS payload value for ${key} must not be quote-wrapped`);
+  }
+  if (/[\u0000-\u001f\u007f]/.test(value)) {
+    throw new Error(`Decrypted SOPS payload value for ${key} must not contain control characters`);
+  }
+  if (numericSecretKeys.has(key) && !/^[0-9]+$/.test(value)) {
+    throw new Error(`Decrypted SOPS payload value for ${key} must contain decimal digits only`);
+  }
+  return value;
+}
+
+function decryptSopsPayload(ciphertext: string, output: string): void {
+  run("sops", [
+    "decrypt",
+    "--input-type",
+    "dotenv",
+    "--output-type",
+    "json",
+    "--output",
+    output,
+    ciphertext,
+  ]);
+}
+
+function assertRegularFile(path: string, label: string): void {
+  if (!existsSync(path)) {
+    throw new Error(`${label} must be one regular non-symlink file: ${path}`);
+  }
+
+  const status = lstatSync(path);
+  if (!status.isFile() || status.isSymbolicLink()) {
+    throw new Error(`${label} must be one regular non-symlink file: ${path}`);
+  }
+}
+
+function assertSafeOutput(output: string): void {
+  const normalizedOutput = normalize(output);
+  if (output === "" || isAbsolute(output) || normalizedOutput === ".." || normalizedOutput.startsWith("../")) {
+    throw new Error("SECRETS_OUTPUT must be a repository-relative ignored path");
+  }
+
+  const ignored = spawnSync("git", ["check-ignore", "-q", "--", normalizedOutput], {
+    cwd: repoRoot,
+    stdio: "ignore",
+  });
+  if (ignored.status !== 0) {
+    throw new Error(`SECRETS_OUTPUT is not gitignored: ${output}`);
+  }
+
+  let component = repoRoot;
+  for (const segment of dirname(normalizedOutput).split("/").filter((value) => value !== ".")) {
+    component = join(component, segment);
+    if (existsSync(component) && lstatSync(component).isSymbolicLink()) {
+      throw new Error(`SECRETS_OUTPUT path must not contain symlinks: ${output}`);
+    }
+  }
+
+  const absoluteOutput = join(repoRoot, normalizedOutput);
+  if (existsSync(absoluteOutput)) {
+    assertRegularFile(absoluteOutput, "SECRETS_OUTPUT");
   }
 }
 

--- a/scripts/roku-task/secrets.ts
+++ b/scripts/roku-task/secrets.ts
@@ -11,7 +11,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { basename, dirname, isAbsolute, join, normalize } from "node:path";
+import { basename, dirname, isAbsolute, join, normalize, sep } from "node:path";
 import process from "node:process";
 import { envOr, repoRoot, requireEnv, run } from "./runtime.ts";
 
@@ -60,9 +60,8 @@ export function secretsSetup(decryptPayload: DecryptPayload = decryptSopsPayload
     "PUTIO_ROKU_SOPS_FILE",
     "PUTIO_ROKU_SOPS_FILE=/path/to/roku.sops.env pnpm roku secrets-setup",
   );
-  const output = envOr("SECRETS_OUTPUT", ".env.local");
+  const output = safeOutputPath(envOr("SECRETS_OUTPUT", ".env.local"));
   assertRegularFile(ciphertext, "ciphertext input");
-  assertSafeOutput(output);
 
   const tempDir = mkdtempSync(join(tmpdir(), "putio-roku-secrets-"));
   chmodSync(tempDir, 0o700);
@@ -172,7 +171,7 @@ function assertRegularFile(path: string, label: string): void {
   }
 }
 
-function assertSafeOutput(output: string): void {
+function safeOutputPath(output: string): string {
   const normalizedOutput = normalize(output);
   if (output === "" || isAbsolute(output) || normalizedOutput === ".." || normalizedOutput.startsWith("../")) {
     throw new Error("SECRETS_OUTPUT must be a repository-relative ignored path");
@@ -187,7 +186,7 @@ function assertSafeOutput(output: string): void {
   }
 
   let component = repoRoot;
-  for (const segment of dirname(normalizedOutput).split("/").filter((value) => value !== ".")) {
+  for (const segment of dirname(normalizedOutput).split(sep).filter((value) => value !== ".")) {
     component = join(component, segment);
     if (existsSync(component) && lstatSync(component).isSymbolicLink()) {
       throw new Error(`SECRETS_OUTPUT path must not contain symlinks: ${output}`);
@@ -198,6 +197,8 @@ function assertSafeOutput(output: string): void {
   if (existsSync(absoluteOutput)) {
     assertRegularFile(absoluteOutput, "SECRETS_OUTPUT");
   }
+
+  return normalizedOutput;
 }
 
 function installSecretFile(source: string, output: string): void {

--- a/test/live-test/secrets.test.ts
+++ b/test/live-test/secrets.test.ts
@@ -1,57 +1,136 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  lstatSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
-import { resolveSecretExportFile } from "../../scripts/roku-task/secrets.ts";
+import { parseEnv } from "node:util";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  parseSecretPayload,
+  renderSecretPayload,
+  secretsSetup,
+  type RokuSecretPayload,
+} from "../../scripts/roku-task/secrets.ts";
 
 const tempDirs: string[] = [];
+const outputs: string[] = [];
+
+const validPayload: RokuSecretPayload = {
+  AUDIO_CONTENT_ID: "1",
+  IMAGE_CONTENT_ID: "2",
+  PLAYBACK_CONTENT_ID: "3",
+  PUTIO_CLI_CONFIG_PATH: ".putio-cli/devs-fe-auto.json",
+  PUTIO_CLI_PROFILE: "devs-fe-auto",
+  PUTIO_CLIENT_ID_FIRST_PARTY: "4",
+  PUTIO_CLIENT_SECRET_FIRST_PARTY: "client-secret",
+  PUTIO_TEST_PASSWORD: "password",
+  PUTIO_TEST_TOTP_REFERENCE: "reference",
+  PUTIO_TEST_USERNAME: "username",
+  ROKU_DEV_PASSWORD: "device-password",
+  SUBTITLE_CONTENT_ID: "5",
+};
 
 afterEach(() => {
+  vi.unstubAllEnvs();
+  for (const output of outputs.splice(0)) {
+    rmSync(output, { force: true });
+  }
   for (const tempDir of tempDirs.splice(0)) {
     rmSync(tempDir, { force: true, recursive: true });
   }
 });
 
-describe("Infisical export output", () => {
-  it("accepts the requested output path", () => {
-    const requestedPath = makeRequestedPath();
-    writeFileSync(requestedPath, "EXAMPLE=value\n");
-
-    expect(resolveSecretExportFile(requestedPath)).toBe(requestedPath);
+describe("Roku SOPS payload", () => {
+  it("parses the exact contract and renders a dotenv round trip", () => {
+    const parsed = parseSecretPayload(JSON.stringify(validPayload));
+    expect(parsed).toEqual(validPayload);
+    expect(parseEnv(renderSecretPayload(parsed))).toEqual(validPayload);
   });
 
-  it("accepts the dotenv suffix added by Infisical", () => {
-    const requestedPath = makeRequestedPath();
-    writeFileSync(`${requestedPath}.env`, "EXAMPLE=value\n");
-
-    expect(resolveSecretExportFile(requestedPath)).toBe(`${requestedPath}.env`);
+  it("rejects missing, extra, empty, non-string, wrapped, and malformed numeric values", () => {
+    expect(() => parseSecretPayload(JSON.stringify(withoutKey(validPayload, "AUDIO_CONTENT_ID")))).toThrow(
+      "key inventory does not match",
+    );
+    expect(() => parseSecretPayload(JSON.stringify({ ...validPayload, UNKNOWN: "value" }))).toThrow(
+      "key inventory does not match",
+    );
+    expect(() => parseSecretPayload(JSON.stringify({ ...validPayload, PUTIO_TEST_PASSWORD: "" }))).toThrow(
+      "must not be empty",
+    );
+    expect(() => parseSecretPayload(JSON.stringify({ ...validPayload, PUTIO_TEST_PASSWORD: 42 }))).toThrow(
+      "must be a string",
+    );
+    expect(() => parseSecretPayload(JSON.stringify({ ...validPayload, PUTIO_TEST_PASSWORD: '"wrapped"' }))).toThrow(
+      "must not be quote-wrapped",
+    );
+    expect(() => parseSecretPayload(JSON.stringify({ ...validPayload, AUDIO_CONTENT_ID: "not-numeric" }))).toThrow(
+      "must contain decimal digits only",
+    );
   });
 
-  it("rejects missing or ambiguous export output", () => {
-    const requestedPath = makeRequestedPath();
-    expect(() => resolveSecretExportFile(requestedPath)).toThrow(
-      "Infisical export wrote 0 recognized output files",
-    );
+  it("writes one ignored mode-0600 env file and removes its temporary directory", () => {
+    const tempDir = makeTempDir();
+    const ciphertext = join(tempDir, "roku.sops.env");
+    writeFileSync(ciphertext, "ciphertext");
+    const output = `.env.local.sops-test-${process.pid}-${Date.now()}`;
+    outputs.push(output);
+    vi.stubEnv("PUTIO_ROKU_SOPS_FILE", ciphertext);
+    vi.stubEnv("SECRETS_OUTPUT", output);
+    const before = rokuSecretTempDirs();
 
-    writeFileSync(requestedPath, "FIRST=value\n");
-    writeFileSync(`${requestedPath}.env`, "SECOND=value\n");
-    expect(() => resolveSecretExportFile(requestedPath)).toThrow(
-      "Infisical export wrote 2 recognized output files",
-    );
+    secretsSetup((_input, decryptedOutput) => {
+      writeFileSync(decryptedOutput, JSON.stringify(validPayload), { mode: 0o600 });
+    });
+
+    expect(parseEnv(readFileSync(output, "utf8"))).toEqual(validPayload);
+    expect(lstatSync(output).mode & 0o777).toBe(0o600);
+    expect(rokuSecretTempDirs()).toEqual(before);
   });
 
-  it("rejects a non-regular export artifact", () => {
-    const requestedPath = makeRequestedPath();
-    mkdirSync(requestedPath);
+  it("rejects symlinked ciphertext and output paths", () => {
+    const tempDir = makeTempDir();
+    const ciphertext = join(tempDir, "roku.sops.env");
+    const ciphertextLink = join(tempDir, "ciphertext-link");
+    writeFileSync(ciphertext, "ciphertext");
+    symlinkSync(ciphertext, ciphertextLink);
+    vi.stubEnv("PUTIO_ROKU_SOPS_FILE", ciphertextLink);
+    vi.stubEnv("SECRETS_OUTPUT", `.env.local.sops-test-${process.pid}-${Date.now()}`);
 
-    expect(() => resolveSecretExportFile(requestedPath)).toThrow(
-      `Infisical export output is not a regular file: ${requestedPath}`,
-    );
+    expect(() => secretsSetup()).toThrow("ciphertext input must be one regular non-symlink file");
+
+    const outputTarget = `.env.local.sops-target-${process.pid}-${Date.now()}`;
+    const outputLink = `.env.local.sops-link-${process.pid}-${Date.now()}`;
+    outputs.push(outputTarget, outputLink);
+    writeFileSync(outputTarget, "target");
+    symlinkSync(outputTarget, outputLink);
+    vi.stubEnv("PUTIO_ROKU_SOPS_FILE", ciphertext);
+    vi.stubEnv("SECRETS_OUTPUT", outputLink);
+
+    expect(() => secretsSetup()).toThrow("SECRETS_OUTPUT must be one regular non-symlink file");
   });
 });
 
-function makeRequestedPath(): string {
+function makeTempDir(): string {
   const tempDir = mkdtempSync(join(tmpdir(), "putio-roku-secrets-test-"));
   tempDirs.push(tempDir);
-  return join(tempDir, "env");
+  return tempDir;
+}
+
+function rokuSecretTempDirs(): readonly string[] {
+  return readdirSync(tmpdir())
+    .filter((entry) => entry.startsWith("putio-roku-secrets-"))
+    .sort();
+}
+
+function withoutKey(
+  payload: RokuSecretPayload,
+  omitted: keyof RokuSecretPayload,
+): Record<string, string> {
+  return Object.fromEntries(Object.entries(payload).filter(([key]) => key !== omitted));
 }

--- a/test/live-test/secrets.test.ts
+++ b/test/live-test/secrets.test.ts
@@ -93,6 +93,22 @@ describe("Roku SOPS payload", () => {
     expect(rokuSecretTempDirs()).toEqual(before);
   });
 
+  it("installs to the validated normalized output path", () => {
+    const tempDir = makeTempDir();
+    const ciphertext = join(tempDir, "roku.sops.env");
+    writeFileSync(ciphertext, "ciphertext");
+    const output = `.env.local.sops-normalized-${process.pid}-${Date.now()}`;
+    outputs.push(output);
+    vi.stubEnv("PUTIO_ROKU_SOPS_FILE", ciphertext);
+    vi.stubEnv("SECRETS_OUTPUT", `missing/../${output}`);
+
+    secretsSetup((_input, decryptedOutput) => {
+      writeFileSync(decryptedOutput, JSON.stringify(validPayload), { mode: 0o600 });
+    });
+
+    expect(parseEnv(readFileSync(output, "utf8"))).toEqual(validPayload);
+  });
+
   it("rejects symlinked ciphertext and output paths", () => {
     const tempDir = makeTempDir();
     const ciphertext = join(tempDir, "roku.sops.env");


### PR DESCRIPTION
## Summary

Replace the Roku live-test Infisical dependency with a provider-neutral SOPS input contract.

## Changed

- decrypt one maintainer-supplied SOPS payload on demand
- fail closed on key drift, empty or wrapped values, malformed identifiers, symlinks, and tracked outputs
- canonicalize the validated output path before atomic mode-0600 installation
- update public onboarding without exposing private vault coordinates

## Review aids

Input: PUTIO_ROKU_SOPS_FILE points to an authorized encrypted dotenv payload.

Output: pnpm roku secrets-setup writes an ignored .env.local containing the exact validated 12-key contract.

## Risks

The migration changes maintainer onboarding and removes the old Infisical variables. Local device targets remain in .env and are not part of the encrypted shared payload.

## Verification

- pnpm verify: 11 files and 44 tests passed; formatting, static checks, visual manifest, and production ZIP passed
- real encrypted payload rendered with exact 12-key and value parity at mode 0600
- unrelated age identity was denied without changing the existing output
- migrated credentials prepared and revalidated a default-scope put.io CLI profile
- migrated Roku Developer Mode password installed and launched the verified checkout on physical hardware
- authenticated device-code bootstrap reached homeScreen

The broader files flow later lost SceneGraph connectivity on the old Roku Stick; that device stability gap is separate from the secret cutover.