### PR TITLE
ci(release): resolve releaser bot user id at runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,20 @@ jobs:
           private-key: ${{ secrets.PUTIO_RELEASE_BOT_PRIVATE_KEY }}
           permission-contents: write
 
+      - name: Resolve release bot identity
+        id: release-bot-identity
+        env:
+          GH_TOKEN: ${{ steps.release-bot.outputs.token }}
+          APP_SLUG: ${{ steps.release-bot.outputs.app-slug }}
+        run: |
+          set -euo pipefail
+          user_id="$(gh api "/users/${APP_SLUG}[bot]" --jq .id)"
+          if [[ ! "$user_id" =~ ^[0-9]+$ ]]; then
+            echo "failed to resolve numeric bot user id for ${APP_SLUG}[bot]" >&2
+            exit 1
+          fi
+          echo "user-id=${user_id}" >> "$GITHUB_OUTPUT"
+
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -86,6 +100,19 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # The licensed GT America faces are gitignored, so the checkout has none of them and the
+      # packaged app would silently fall back to the Roku system font. Fetch them from put.io's
+      # own CDN before semantic-release builds the artifact. No credential is involved: the
+      # faces are served over plain HTTPS from static.put.io. fonts-setup is the gate -- it
+      # fails on any download or validation problem, so reaching the build means every listed
+      # face is on disk and is a real GT America face. fonts-check then re-checks those bytes,
+      # but note it treats absence as a legitimate optional state, so it would not by itself
+      # catch a step that silently synced nothing.
+      - name: Sync licensed brand fonts
+        run: |
+          pnpm roku fonts-setup
+          pnpm roku fonts-check
+
       - name: Release Roku package
         id: semantic
         uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6.0.0
@@ -100,9 +127,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.release-bot.outputs.token }}
           GIT_AUTHOR_NAME: ${{ steps.release-bot.outputs.app-slug }}[bot]
-          GIT_AUTHOR_EMAIL: 283001373+${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com
+          GIT_AUTHOR_EMAIL: ${{ steps.release-bot-identity.outputs.user-id }}+${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com
           GIT_COMMITTER_NAME: ${{ steps.release-bot.outputs.app-slug }}[bot]
-          GIT_COMMITTER_EMAIL: 283001373+${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com
+          GIT_COMMITTER_EMAIL: ${{ steps.release-bot-identity.outputs.user-id }}+${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com
 
       # Attach the sideload ZIP with the gh CLI instead of @semantic-release/github's
       # octokit uploader, which intermittently fails on large assets with

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,17 +69,18 @@ jobs:
 
       - name: Resolve release bot identity
         id: release-bot-identity
+        shell: bash
         env:
           GH_TOKEN: ${{ steps.release-bot.outputs.token }}
           APP_SLUG: ${{ steps.release-bot.outputs.app-slug }}
         run: |
           set -euo pipefail
-          user_id="$(gh api "/users/${APP_SLUG}[bot]" --jq .id)"
+          user_id="$(gh api "/users/${APP_SLUG}%5Bbot%5D" --jq .id)"
           if [[ ! "$user_id" =~ ^[0-9]+$ ]]; then
             echo "failed to resolve numeric bot user id for ${APP_SLUG}[bot]" >&2
             exit 1
           fi
-          echo "user-id=${user_id}" >> "$GITHUB_OUTPUT"
+          echo "user_id=${user_id}" >> "$GITHUB_OUTPUT"
 
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -100,18 +101,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # The licensed GT America faces are gitignored, so the checkout has none of them and the
-      # packaged app would silently fall back to the Roku system font. Fetch them from put.io's
-      # own CDN before semantic-release builds the artifact. No credential is involved: the
-      # faces are served over plain HTTPS from static.put.io. fonts-setup is the gate -- it
-      # fails on any download or validation problem, so reaching the build means every listed
-      # face is on disk and is a real GT America face. fonts-check then re-checks those bytes,
-      # but note it treats absence as a legitimate optional state, so it would not by itself
-      # catch a step that silently synced nothing.
-      - name: Sync licensed brand fonts
-        run: |
-          pnpm roku fonts-setup
-          pnpm roku fonts-check
 
       - name: Release Roku package
         id: semantic
@@ -127,9 +116,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.release-bot.outputs.token }}
           GIT_AUTHOR_NAME: ${{ steps.release-bot.outputs.app-slug }}[bot]
-          GIT_AUTHOR_EMAIL: ${{ steps.release-bot-identity.outputs.user-id }}+${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com
+          GIT_AUTHOR_EMAIL: ${{ steps.release-bot-identity.outputs.user_id }}+${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com
           GIT_COMMITTER_NAME: ${{ steps.release-bot.outputs.app-slug }}[bot]
-          GIT_COMMITTER_EMAIL: ${{ steps.release-bot-identity.outputs.user-id }}+${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com
+          GIT_COMMITTER_EMAIL: ${{ steps.release-bot-identity.outputs.user_id }}+${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com
 
       # Attach the sideload ZIP with the gh CLI instead of @semantic-release/github's
       # octokit uploader, which intermittently fails on large assets with


### PR DESCRIPTION
## Summary
- Resolve the release bot numeric user id at runtime via `/users/{app-slug}[bot]`
- Use that id in noreply commit emails instead of a hardcoded value

## Test plan
- [ ] CI green on this PR
- [ ] Next release commit email links to `putio-releaser[bot]`

## Review aids
Before: `283001373+${{ steps.release-bot.outputs.app-slug }}[bot]@…`
After: `${{ steps.release-bot-identity.outputs.user-id }}+${{ steps.release-bot.outputs.app-slug }}[bot]@…`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves the release bot user ID at runtime and hardens the lookup so noreply commit email links stay correct even if the GitHub App is recreated. Also syncs GT America fonts during CI to prevent Roku fallback.

- **Bug Fixes**
  - Resolve and validate bot ID via `gh api /users/{app-slug}%5Bbot%5D` (Bash, URL-encoded), expose as `user_id`, and use it in `GIT_AUTHOR_EMAIL`/`GIT_COMMITTER_EMAIL`.
  - Sync and verify GT America fonts with `pnpm roku fonts-setup` and `pnpm roku fonts-check` before `semantic-release` builds.

<sup>Written for commit 83af23ce2d9840b9152cffcfd6f566de3dc32bdc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

