### PR TITLE
chore: remove internal automation profile from tracked files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,8 +8,8 @@ ROKU_DEV_TARGET="192.168.0.10"
 ROKU_DEV_PASSWORD=""
 
 # Optional put.io CLI harness auth. Keep the config path local and ignored.
-PUTIO_CLI_PROFILE="devs-fe-auto"
-PUTIO_CLI_CONFIG_PATH=".putio-cli/devs-fe-auto.json"
+PUTIO_CLI_PROFILE="<profile-name>"
+PUTIO_CLI_CONFIG_PATH=".putio-cli/<profile-name>.json"
 PUTIO_TEST_USERNAME=""
 PUTIO_TEST_PASSWORD=""
 PUTIO_TEST_TOTP_REFERENCE=""

--- a/live-test/README.md
+++ b/live-test/README.md
@@ -54,14 +54,18 @@ PLAYER_UI_REFERENCE_IMAGE=<path-to-reference-image>
 Optional for authenticated harness setup:
 
 ```bash
-PUTIO_CLI_PROFILE=devs-fe-auto
-PUTIO_CLI_CONFIG_PATH=.putio-cli/devs-fe-auto.json
+PUTIO_CLI_PROFILE=<profile-name>
+PUTIO_CLI_CONFIG_PATH=.putio-cli/<profile-name>.json
 PUTIO_TEST_USERNAME=<testing-account-username>
 PUTIO_TEST_PASSWORD=<testing-account-password>
 PUTIO_TEST_TOTP_REFERENCE=<testing-account-totp-secret>
 PUTIO_CLIENT_ID_FIRST_PARTY=<oauth-client-id>
 PUTIO_CLIENT_SECRET_FIRST_PARTY=<oauth-client-secret>
 ```
+
+Pick any local profile name; when unset, harness scripts fall back to the
+`default` profile at `.putio-cli/default.json`. Maintainers get the real
+profile values from the SOPS payload via `pnpm roku secrets-setup`.
 
 Keep `.env` and `.env.local` local. Device IPs, Developer Mode passwords,
 signing keys, and download tokens do not belong in git. `.putio-cli/` is ignored

--- a/live-test/README.md
+++ b/live-test/README.md
@@ -54,13 +54,13 @@ PLAYER_UI_REFERENCE_IMAGE=<path-to-reference-image>
 Optional for authenticated harness setup:
 
 ```bash
-PUTIO_CLI_PROFILE=<profile-name>
-PUTIO_CLI_CONFIG_PATH=.putio-cli/<profile-name>.json
-PUTIO_TEST_USERNAME=<testing-account-username>
-PUTIO_TEST_PASSWORD=<testing-account-password>
-PUTIO_TEST_TOTP_REFERENCE=<testing-account-totp-secret>
-PUTIO_CLIENT_ID_FIRST_PARTY=<oauth-client-id>
-PUTIO_CLIENT_SECRET_FIRST_PARTY=<oauth-client-secret>
+PUTIO_CLI_PROFILE="<profile-name>"
+PUTIO_CLI_CONFIG_PATH=".putio-cli/<profile-name>.json"
+PUTIO_TEST_USERNAME="<testing-account-username>"
+PUTIO_TEST_PASSWORD="<testing-account-password>"
+PUTIO_TEST_TOTP_REFERENCE="<testing-account-totp-secret>"
+PUTIO_CLIENT_ID_FIRST_PARTY="<oauth-client-id>"
+PUTIO_CLIENT_SECRET_FIRST_PARTY="<oauth-client-secret>"
 ```
 
 Pick any local profile name; when unset, harness scripts fall back to the

--- a/scripts/live-test/putio-config.ts
+++ b/scripts/live-test/putio-config.ts
@@ -13,7 +13,7 @@ type PutioCliConfig = {
 };
 
 export function putioProfileFromArg(rawProfile?: string): string {
-  return rawProfile?.trim() || process.env.PUTIO_CLI_PROFILE?.trim() || "devs-fe-auto";
+  return rawProfile?.trim() || process.env.PUTIO_CLI_PROFILE?.trim() || "default";
 }
 
 export async function setPlaybackTypeConfig(

--- a/scripts/live-test/usage.ts
+++ b/scripts/live-test/usage.ts
@@ -29,8 +29,8 @@ export function usage(): never {
 environment:
   ROKU_DEV_TARGET=<roku-ip> or ROKIT_TARGET=<roku-ip>
   ROKU_DEV_PASSWORD=<developer-mode-password> or ROKIT_PASSWORD=<developer-mode-password>
-  PUTIO_CLI_PROFILE=devs-fe-auto
-  PUTIO_CLI_CONFIG_PATH=.putio-cli/devs-fe-auto.json
+  PUTIO_CLI_PROFILE=<profile-name>
+  PUTIO_CLI_CONFIG_PATH=.putio-cli/<profile-name>.json
   IMAGE_CONTENT_ID=<optional-image-file-id-for-image-flow-and-visual-pages>
   PLAYER_UI_REFERENCE_IMAGE=<optional-reference-image-path>`);
   process.exit(1);

--- a/scripts/live-test/usage.ts
+++ b/scripts/live-test/usage.ts
@@ -27,11 +27,11 @@ export function usage(): never {
   node scripts/roku-live-test.ts control-smoke
 
 environment:
-  ROKU_DEV_TARGET=<roku-ip> or ROKIT_TARGET=<roku-ip>
-  ROKU_DEV_PASSWORD=<developer-mode-password> or ROKIT_PASSWORD=<developer-mode-password>
-  PUTIO_CLI_PROFILE=<profile-name>
-  PUTIO_CLI_CONFIG_PATH=.putio-cli/<profile-name>.json
-  IMAGE_CONTENT_ID=<optional-image-file-id-for-image-flow-and-visual-pages>
-  PLAYER_UI_REFERENCE_IMAGE=<optional-reference-image-path>`);
+  ROKU_DEV_TARGET="<roku-ip>" or ROKIT_TARGET="<roku-ip>"
+  ROKU_DEV_PASSWORD="<developer-mode-password>" or ROKIT_PASSWORD="<developer-mode-password>"
+  PUTIO_CLI_PROFILE="<profile-name>"
+  PUTIO_CLI_CONFIG_PATH=".putio-cli/<profile-name>.json"
+  IMAGE_CONTENT_ID="<optional-image-file-id-for-image-flow-and-visual-pages>"
+  PLAYER_UI_REFERENCE_IMAGE="<optional-reference-image-path>"`);
   process.exit(1);
 }

--- a/scripts/putio-auth-harness.ts
+++ b/scripts/putio-auth-harness.ts
@@ -71,13 +71,13 @@ function usage(): never {
   node scripts/putio-auth-harness.ts auth-approve-device <device-code> [profile]
 
 environment:
-  PUTIO_CLI_PROFILE=<profile-name>
-  PUTIO_CLI_CONFIG_PATH=.putio-cli/<profile-name>.json
-  PUTIO_TEST_USERNAME=<testing-account-email>
-  PUTIO_TEST_PASSWORD=<secret>
-  PUTIO_TEST_TOTP_REFERENCE=<base32-secret>
-  PUTIO_CLIENT_ID_FIRST_PARTY=<oauth-client-id>
-  PUTIO_CLIENT_SECRET_FIRST_PARTY=<oauth-client-secret>`);
+  PUTIO_CLI_PROFILE="<profile-name>"
+  PUTIO_CLI_CONFIG_PATH=".putio-cli/<profile-name>.json"
+  PUTIO_TEST_USERNAME="<testing-account-email>"
+  PUTIO_TEST_PASSWORD="<secret>"
+  PUTIO_TEST_TOTP_REFERENCE="<base32-secret>"
+  PUTIO_CLIENT_ID_FIRST_PARTY="<oauth-client-id>"
+  PUTIO_CLIENT_SECRET_FIRST_PARTY="<oauth-client-secret>"`);
   process.exit(1);
 }
 

--- a/scripts/putio-auth-harness.ts
+++ b/scripts/putio-auth-harness.ts
@@ -8,7 +8,7 @@ import { execFile as execFileCallback } from "node:child_process";
 
 const execFile = promisify(execFileCallback);
 
-const defaultProfile = "devs-fe-auto";
+const defaultProfile = "default";
 const defaultApiBaseUrl = "https://api.put.io";
 const totpAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
 
@@ -71,9 +71,9 @@ function usage(): never {
   node scripts/putio-auth-harness.ts auth-approve-device <device-code> [profile]
 
 environment:
-  PUTIO_CLI_PROFILE=devs-fe-auto
-  PUTIO_CLI_CONFIG_PATH=.putio-cli/devs-fe-auto.json
-  PUTIO_TEST_USERNAME=devs+fe+auto@put.io
+  PUTIO_CLI_PROFILE=<profile-name>
+  PUTIO_CLI_CONFIG_PATH=.putio-cli/<profile-name>.json
+  PUTIO_TEST_USERNAME=<testing-account-email>
   PUTIO_TEST_PASSWORD=<secret>
   PUTIO_TEST_TOTP_REFERENCE=<base32-secret>
   PUTIO_CLIENT_ID_FIRST_PARTY=<oauth-client-id>

--- a/scripts/roku-live-test.ts
+++ b/scripts/roku-live-test.ts
@@ -1332,8 +1332,8 @@ async function main(): Promise<void> {
   } else if (command === "auth-refresh-smoke") {
     await authRefreshSmoke(target);
   } else if (command === "auth-prepare") {
-    const [profile = process.env.PUTIO_CLI_PROFILE ?? "default"] = args;
-    await waitForAuthReady(target, profile);
+    const [rawProfile] = args;
+    await waitForAuthReady(target, putioProfileFromArg(rawProfile));
   } else if (command === "flow-smoke") {
     const [rawArtifactDir] = args;
     await runNamedFlowSuite(

--- a/scripts/roku-live-test.ts
+++ b/scripts/roku-live-test.ts
@@ -1332,7 +1332,7 @@ async function main(): Promise<void> {
   } else if (command === "auth-refresh-smoke") {
     await authRefreshSmoke(target);
   } else if (command === "auth-prepare") {
-    const [profile = process.env.PUTIO_CLI_PROFILE ?? "devs-fe-auto"] = args;
+    const [profile = process.env.PUTIO_CLI_PROFILE ?? "default"] = args;
     await waitForAuthReady(target, profile);
   } else if (command === "flow-smoke") {
     const [rawArtifactDir] = args;

--- a/scripts/roku-task/runtime.ts
+++ b/scripts/roku-task/runtime.ts
@@ -19,7 +19,7 @@ export const zipDir = join(distDir, "apps");
 export const tmpDir = join(distDir, "tmp");
 export const artifactName = "putio-roku-v2.zip";
 
-const defaultProfile = "devs-fe-auto";
+const defaultProfile = "default";
 
 export function loadEnvFiles(paths: readonly string[]): void {
   for (let index = paths.length - 1; index >= 0; index -= 1) {


### PR DESCRIPTION
**Problem:** the public repo shipped the internal automation account profile `PUTIO_CLI_PROFILE` value in `.env.example:11-12`, `live-test/README.md`, harness usage text, and four code-level fallbacks, plus the testing-account email in `scripts/putio-auth-harness.ts` usage text.

**Solution:**
- `.env.example`, `live-test/README.md`, `scripts/live-test/usage.ts`, `scripts/putio-auth-harness.ts` usage text: `<profile-name>` / `<testing-account-email>` placeholders.
- Code fallbacks (`scripts/live-test/putio-config.ts:16`, `scripts/putio-auth-harness.ts:11`, `scripts/roku-task/runtime.ts:22`, `scripts/roku-live-test.ts:1335`): last-resort default is now the `default` profile at `.putio-cli/default.json`; arg and `PUTIO_CLI_PROFILE` precedence unchanged.
- `live-test/README.md` gains one sentence pointing maintainers at the SOPS payload for real values.

`git grep devs-fe-auto` is empty in tracked files. If the SOPS payload does not set `PUTIO_CLI_PROFILE`, maintainer harness runs now resolve `.putio-cli/default.json` — set the profile in `.env.local` in that case.

Fixes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)