### PR TITLE
feat(design): land the tv.video token group with @putdotio/design 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@phosphor-icons/core": "2.1.1",
-    "@putdotio/design": "^2.0.1",
+    "@putdotio/design": "^3.0.0",
     "@putdotio/rokit": "2.4.2",
     "@putdotio/vref": "1.1.1",
     "@resvg/resvg-js": "^2.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: 2.1.1
         version: 2.1.1
       '@putdotio/design':
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: ^3.0.0
+        version: 3.0.0
       '@putdotio/rokit':
         specifier: 2.4.2
         version: 2.4.2(ioredis@5.10.1)
@@ -209,8 +209,8 @@ packages:
   '@postman/tunnel-agent@0.6.8':
     resolution: {integrity: sha512-2U42SmZW5G+suEcS++zB94sBWNO4qD4bvETGFRFDTqSpYl5ksfjcPqzYpgQgXgUmb6dfz+fAGbkcRamounGm0w==}
 
-  '@putdotio/design@2.0.1':
-    resolution: {integrity: sha512-ZXy7opHsluAtDMgFp5SaZWUnsjsX9PNJTivOgCcHpVU487SHoMsDcDe8tonSRQtImVST82NRKaKOdBX8CgxjkQ==}
+  '@putdotio/design@3.0.0':
+    resolution: {integrity: sha512-C4m/v7Z4LJUEXV8VGcL3Owb+16yyCqDZU15+7fj5c5S82UsuXDztW383liQEb68NlQItcj03AJldfD5XOkIqKQ==}
 
   '@putdotio/rokit@2.4.2':
     resolution: {integrity: sha512-GVSiqnrAezbWxSQnlSMv/7byLTowcowLw0L5gltsGSWNo65t0EJW8GQ9iMq7hE+x6bXgNEMKbp03c5l47j4czA==}
@@ -817,8 +817,8 @@ packages:
   ecc-jsbn@0.1.2:
     resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
 
-  effect@4.0.0-beta.102:
-    resolution: {integrity: sha512-z8Y+Q76Hh/kjLFZrXu8tGn6e+tDsg45R+UHhxd190pXxD53OGwf/G/zDxXTkse4HJ5mobNZfitLfUCp4fMvu6w==}
+  effect@4.0.0-beta.107:
+    resolution: {integrity: sha512-OoBAv8eF+yanc+C6xhgEUnWeXUSHA6ynnscYqpkAY9GSnzZWystsIjBowVqCkLpHGlnRtdIqYT3wHwpOY6JDnQ==}
 
   effect@4.0.0-beta.97:
     resolution: {integrity: sha512-pK03HpQVxGZOWdwDAy/iwvV8u3KYcUf2mOWyWqaut2zau8V2u6ejWP7b4BELjyUIiZWW1fl/s/VJpgZUcTjThg==}
@@ -1567,10 +1567,6 @@ packages:
     resolution: {integrity: sha512-m0vXfHODcw3gk+KONAOlVQ5yNHc3yS3B1ybM3HS1vqDoS0RWTDDVBVVTYi8hH0k+2OM1vmo9fb1WX9EVqjqfHA==}
     engines: {node: '>=20'}
 
-  toml@4.3.0:
-    resolution: {integrity: sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A==}
-    engines: {node: '>=20'}
-
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -2061,7 +2057,7 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  '@putdotio/design@2.0.1': {}
+  '@putdotio/design@3.0.0': {}
 
   '@putdotio/rokit@2.4.2(ioredis@5.10.1)':
     dependencies:
@@ -2077,7 +2073,7 @@ snapshots:
 
   '@putdotio/vref@1.1.1':
     dependencies:
-      effect: 4.0.0-beta.102
+      effect: 4.0.0-beta.107
 
   '@resvg/resvg-js-android-arm-eabi@2.6.2':
     optional: true
@@ -2587,18 +2583,13 @@ snapshots:
       jsbn: 0.1.1
       safer-buffer: 2.1.2
 
-  effect@4.0.0-beta.102:
+  effect@4.0.0-beta.107:
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 4.9.0
-      find-my-way-ts: 0.1.6
-      ini: 7.0.0
       kubernetes-types: 1.30.0
       msgpackr: 2.0.5
-      multipasta: 0.2.8
-      toml: 4.3.0
       uuid: 14.0.1
-      yaml: 2.9.0
 
   effect@4.0.0-beta.97:
     dependencies:
@@ -3360,8 +3351,6 @@ snapshots:
       is-number: 7.0.0
 
   toml@4.1.2: {}
-
-  toml@4.3.0: {}
 
   tslib@2.8.1: {}
 

--- a/scripts/generate-roku-design.ts
+++ b/scripts/generate-roku-design.ts
@@ -38,7 +38,11 @@ const rokuTokens: readonly RokuToken[] = [
   { name: "text", key: "color.neutral.dark.text" },
   { name: "textInverse", key: "component.button.primary.foreground" },
   { name: "textMuted", key: "color.neutral.dark.textSecondary" },
+  { name: "textOnVideo", key: "tv.video.textOnVideo" },
   { name: "transparent", key: "surface.dark.listItemBg" },
+  { name: "videoBackground", key: "tv.video.background" },
+  { name: "videoHeroScrimBottom", key: "tv.video.heroScrimBottom" },
+  { name: "videoHeroScrimTop", key: "tv.video.heroScrimTop" },
 ];
 
 export async function generateRokuDesign(repoRoot: string): Promise<string> {

--- a/source/DesignTokens.brs
+++ b/source/DesignTokens.brs
@@ -22,7 +22,11 @@ function designTokenColor(name as string) as string
         text: "0xEDEDEDFF",
         textInverse: "0x2A1E09FF",
         textMuted: "0xA0A0A0FF",
+        textOnVideo: "0xFFFFFFFF",
         transparent: "0x00000000",
+        videoBackground: "0x000000FF",
+        videoHeroScrimBottom: "0x050403FF",
+        videoHeroScrimTop: "0x1A1612FF",
     }
 
     if colors.doesExist(name)


### PR DESCRIPTION
putio-design 3.0.0 made Roku an explicit tier and shipped the roku-c* card set; we were pinned to ^2.0.1, so the new `tv.video` colors (video surface, hero scrims, text-on-video) had no path into the channel.

- **Bump:** `@putdotio/design` ^2.0.1 → ^3.0.0.
- **Tokens:** `videoBackground`, `videoHeroScrimTop`, `videoHeroScrimBottom`, `textOnVideo` added to the generator allowlist and landed in `source/DesignTokens.brs`; no consumers wired yet.
- **Measured additive:** full 2.0.1→3.0.0 token diff is 83 added, 0 removed, 0 value changes; regenerated channel art for all three variants is byte-identical, so no existing color moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)