### PR TITLE
fix(search): keep missing history local

### DIFF
--- a/components/screens/Search/Search.brs
+++ b/components/screens/Search/Search.brs
@@ -221,8 +221,7 @@ end sub
 
 sub onPutSearchHistory()
     m.putSearchHistory.unobserveField("response")
-    ' Search history is best-effort; refetch regardless of whether the PUT failed.
-    fetchSearchHistory()
+    ' Keep local history after a best-effort save; a failed write must not restart initialization.
 end sub
 
 sub onFetchSearchHistory(obj)
@@ -234,7 +233,8 @@ sub onFetchSearchHistory(obj)
             m.searchHistoryItems = data.value
             updateSearchHistoryButtons(m.keyboard.text)
         else if data.status_code = 404 or data.status = "OK"
-            putSearchHistory(invalid)
+            m.searchHistoryItems = []
+            updateSearchHistoryButtons(m.keyboard.text)
         end if
     end if
 end sub


### PR DESCRIPTION
Missing search history now stays empty locally. Saving a user's history keeps the local state and no longer starts another GET when the PUT completes, preventing repeated initialization after a failed save.

Device acceptance on a Roku Stick 3500X, Roku OS 11.0.0.4195, at this head:

- **Missing history**: with `/config/search_history` returning `value: null`, Search shows the "No recent searches" empty state and the server value stays null, so no initializing PUT is sent.
  ![missing history](https://attach.uinaf.dev/o/uHa4ac_hXAXPYAdlCd0u4g)
- **Successful persistence**: typing `sintel` and opening a result sent `PUT /config/search_history` with `{"value":["sintel"]}` and got 200. Reopening Search from Home lists `sintel`.
  ![persisted history](https://attach.uinaf.dev/o/57CgDTAHsLlAgRA_AsAqYA)
- **Failed persistence**: a throwaway build pointing the PUT at a path that returns 405 kept `bunny` and `sintel` in the local list, and the console showed no follow-up GET after the failed PUT.
- Ordinary remote-control search over ECP key presses worked throughout.

`pnpm verify` passed; independent review is clean.