### PR TITLE
test(files): require folder navigation and restored focus

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,7 @@ PUTIO_CLIENT_SECRET_FIRST_PARTY=""
 # Optional public Sentry DSN for local packaging. Release builds set it from the
 # PUTIO_ROKU_SENTRY_DSN repository variable; leave it empty to disable reporting.
 PUTIO_ROKU_SENTRY_DSN=""
+
+# Prepared root-level folder for the files flow (zero-based row index).
+FILES_FOLDER_NAME=
+FILES_FOLDER_INDEX=

--- a/live-test/README.md
+++ b/live-test/README.md
@@ -150,6 +150,19 @@ ids are `PLAYBACK_CONTENT_ID`, `IMAGE_CONTENT_ID`, `AUDIO_CONTENT_ID`, and
 need them. Failure snapshots go under `.local/roku-debug/` when ECP is still
 reachable.
 
+The `files` flow requires `FILES_FOLDER_NAME` and `FILES_FOLDER_INDEX` (zero-based).
+Prepare a root-level folder with that unique name at the configured row in the test
+account's current ordering. Its name must differ from the root title. Keep the fixture
+stable during the run; the harness does not create or modify it. For example:
+
+```bash
+FILES_FOLDER_NAME="Navigation fixture" FILES_FOLDER_INDEX=2 FLOWS=files pnpm roku live-test-flow
+```
+
+The flow requires the visible Files header to change to the exact fixture name, then
+requires Back to restore the original header and selected row. This also applies to
+the smoke and full suites, which include `files`. A missing fixture fails the run.
+
 ### Lab And Visuals
 
 | Use | Command | Inputs |

--- a/scripts/live-test/app-flows.ts
+++ b/scripts/live-test/app-flows.ts
@@ -223,12 +223,31 @@ async function filesNavigationFlowSmoke(
   console.log("asserted fixture folder opens and Back restores the parent and selected row");
 }
 
+// The inspector flattens the scene into self-closing tags in document order and links each
+// node to its parent through _sn/_psn serials, so a screen's subtree is the run of tags
+// whose parent chain reaches it. Some leaf nodes omit _psn and stay inside the current
+// subtree. The topmost visible Files screen is the last one listed.
 function filesScreenXml(xml: string): string {
-  const screen = /<FilesScreen\b[^>]*>[\s\S]*?<\/FilesScreen>/u.exec(xml)?.[0];
-  if (screen === undefined || !hasVisibleComponent(screen, "FilesScreen")) {
-    throw new Error("expected visible Files screen");
+  const tags = xml.match(/<[A-Za-z_][^>]*>/gu) ?? [];
+  const serialOf = (tag: string, attribute: "_sn" | "_psn"): string | undefined =>
+    new RegExp(`\\b${attribute}="([^"]*)"`, "u").exec(tag)?.[1];
+  let screenIndex = -1;
+  for (const [index, tag] of tags.entries()) {
+    if (/^<FilesScreen\b/u.test(tag) && !tag.includes('visible="false"')) screenIndex = index;
   }
-  return screen;
+  if (screenIndex === -1) throw new Error("expected visible Files screen");
+  const screenSerial = serialOf(tags[screenIndex] ?? "", "_sn");
+  if (screenSerial === undefined) throw new Error("expected Files screen serial");
+  const subtree = new Set([screenSerial]);
+  const scoped = [tags[screenIndex] ?? ""];
+  for (const tag of tags.slice(screenIndex + 1)) {
+    const parent = serialOf(tag, "_psn");
+    if (parent !== undefined && !subtree.has(parent)) break;
+    const serial = serialOf(tag, "_sn");
+    if (serial !== undefined) subtree.add(serial);
+    scoped.push(tag);
+  }
+  return scoped.join("\n");
 }
 
 function readFilesFolderTitle(xml: string): string {

--- a/scripts/live-test/app-flows.ts
+++ b/scripts/live-test/app-flows.ts
@@ -9,6 +9,7 @@ import type { AppFlowOptions } from "./flow-options.ts";
 import type { FlowId, FlowRunContext } from "./flow-suite.ts";
 import {
   pressKey,
+  querySceneGraph,
   waitForSceneGraphAssertion,
 } from "./rokit-device.ts";
 import {
@@ -16,6 +17,7 @@ import {
   assertNamedNodeVisible,
   hasVisibleComponent,
   readListFocusIndex,
+  readNamedNodeIntegerAttribute,
 } from "./scenegraph.ts";
 import { rokuDesignColor } from "./design-colors.ts";
 
@@ -75,7 +77,7 @@ export async function runAppFlow(
       await driver.waitForAuthReady(context.target, options.profile);
       return;
     case "files":
-      await filesNavigationFlowSmoke(context.target, driver);
+      await filesNavigationFlowSmoke(context.target, options, driver);
       return;
     case "history":
       await historyFlowSmoke(context.target, options.historyExpectedText, driver);
@@ -169,19 +171,23 @@ async function authFlowSmoke(
 
 async function filesNavigationFlowSmoke(
   target: string,
+  options: AppFlowOptions,
   driver: Pick<
     AppFlowDriver,
-    | "assertListHasItems"
-    | "focusListItemByIndex"
-    | "openHomeItem"
-    | "returnToHomeScreen"
-    | "waitForAnyRouteScreenVisible"
+    "assertListHasItems" | "focusListItemByIndex" | "openHomeItem" | "returnToHomeScreen"
   >,
 ): Promise<void> {
+  const { filesFolderName, filesFolderIndex } = options;
+  if (filesFolderName === undefined || filesFolderIndex === undefined) {
+    throw new Error("files flow requires FILES_FOLDER_NAME and FILES_FOLDER_INDEX for a prepared root folder");
+  }
   await driver.returnToHomeScreen(target);
   await driver.openHomeItem(target, 0, "filesScreen");
   const fileCount = await driver.assertListHasItems(target, "fileList");
-  console.log(`asserted files list is populated: ${fileCount} item(s)`);
+  const originalTitle = readFilesFolderTitle(await querySceneGraph(target));
+  if (originalTitle === filesFolderName) {
+    throw new Error("files fixture must have a different title from the root folder");
+  }
 
   await driver.focusListItemByIndex(target, "fileList", 0);
   const visibleFileRows = 6;
@@ -202,15 +208,49 @@ async function filesNavigationFlowSmoke(
   } else {
     console.log(`files wrap check skipped: requires more than ${visibleFileRows} items`);
   }
+  await driver.focusListItemByIndex(target, "fileList", filesFolderIndex);
+  await waitForSceneGraphAssertion(target, "expected fixture folder focus", (xml) => {
+    assertFilesFolder(xml, originalTitle, filesFolderIndex);
+  }, 15_000);
   await pressKey(target, "Select");
-  await driver.waitForAnyRouteScreenVisible(
-    target,
-    ["filesScreen", "videoScreen", "audioScreen", "imageScreen", "videoPlayerScreen"],
-    30_000,
-  );
+  await waitForSceneGraphAssertion(target, "expected fixture folder destination", (xml) => {
+    assertFilesFolder(xml, filesFolderName);
+  }, 30_000);
   await pressKey(target, "Back");
-  await driver.waitForAnyRouteScreenVisible(target, ["filesScreen", "homeScreen"], 30_000);
-  console.log("asserted first files item opens and Back returns to a stable route");
+  await waitForSceneGraphAssertion(target, "expected original folder and focus after Back", (xml) => {
+    assertFilesFolder(xml, originalTitle, filesFolderIndex);
+  }, 30_000);
+  console.log("asserted fixture folder opens and Back restores the parent and selected row");
+}
+
+function filesScreenXml(xml: string): string {
+  const screen = /<FilesScreen\b[^>]*>[\s\S]*?<\/FilesScreen>/u.exec(xml)?.[0];
+  if (screen === undefined || !hasVisibleComponent(screen, "FilesScreen")) {
+    throw new Error("expected visible Files screen");
+  }
+  return screen;
+}
+
+function readFilesFolderTitle(xml: string): string {
+  const screen = filesScreenXml(xml);
+  const title = readNamedNodeAttribute(screen, "titleLabel", "text");
+  if (title === undefined || title === "") throw new Error("expected Files folder title");
+  return title;
+}
+
+function assertFilesFolder(xml: string, expectedTitle: string, focusIndex?: number): void {
+  const screen = filesScreenXml(xml);
+  assertNamedNodeText(screen, "titleLabel", expectedTitle);
+  assertNamedNodeHidden(screen, "loading");
+  if (focusIndex !== undefined) {
+    assertNamedNodeVisible(screen, "fileList");
+    const focusAttribute = readNamedNodeAttribute(screen, "fileList", "focusItem") === undefined
+      ? "itemFocused"
+      : "focusItem";
+    if (readNamedNodeIntegerAttribute(screen, "fileList", focusAttribute) !== focusIndex) {
+      throw new Error("expected Files selection to return to the fixture row");
+    }
+  }
 }
 
 async function historyFlowSmoke(

--- a/scripts/live-test/flow-options.ts
+++ b/scripts/live-test/flow-options.ts
@@ -5,6 +5,8 @@ export type StartFromChoice = "continue" | "beginning";
 
 export type AppFlowOptions = {
   readonly profile: string;
+  readonly filesFolderName?: string;
+  readonly filesFolderIndex?: number;
   readonly playbackContentId?: string;
   readonly imageContentId?: string;
   readonly audioContentId?: string;
@@ -25,6 +27,8 @@ export function appFlowOptionsFromArgs(args: readonly string[]): AppFlowOptions 
 
   return {
     profile: putioProfileFromArg(),
+    filesFolderName: emptyStringAsUndefined(process.env.FILES_FOLDER_NAME),
+    filesFolderIndex: filesFolderIndexFromEnv(process.env.FILES_FOLDER_INDEX),
     playbackContentId: emptyStringAsUndefined(rawPlaybackContentId),
     imageContentId: emptyStringAsUndefined(process.env.IMAGE_CONTENT_ID),
     audioContentId: emptyStringAsUndefined(rawAudioContentId),
@@ -46,4 +50,14 @@ export function startFromChoiceFromArg(value: string): StartFromChoice {
 export function emptyStringAsUndefined(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
   return trimmed === undefined || trimmed === "" ? undefined : trimmed;
+}
+
+function filesFolderIndexFromEnv(value: string | undefined): number | undefined {
+  const input = emptyStringAsUndefined(value);
+  if (input === undefined) return undefined;
+  const index = Number(input);
+  if (!/^\d+$/u.test(input) || !Number.isSafeInteger(index)) {
+    throw new Error("FILES_FOLDER_INDEX must be a non-negative integer");
+  }
+  return index;
 }

--- a/test/live-test/files-flow.test.ts
+++ b/test/live-test/files-flow.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { runAppFlow, type AppFlowDriver } from "../../scripts/live-test/app-flows.ts";
+
+const device = vi.hoisted(() => ({
+  folder: "Your Files",
+  focus: 2,
+  focusAttribute: "focusItem",
+  selectWorks: true,
+  backWorks: true,
+  restoreFocus: true,
+  keys: [] as string[],
+}));
+
+function snapshot(): string {
+  const focus = device.focusAttribute ? `${device.focusAttribute}="${device.focus}"` : "";
+  return `<Scene><SearchScreen visible="false"><Label name="titleLabel" text="Fixture folder" /></SearchScreen><FilesScreen name="filesScreen" visible="true"><ScreenHeader><Label name="titleLabel" text="${device.folder}" /></ScreenHeader><LoadingIndicator name="loading" visible="false" /><MarkupList name="fileList" visible="true" ${focus} count="4" /></FilesScreen></Scene>`;
+}
+
+vi.mock("../../scripts/live-test/rokit-device.ts", () => ({
+  querySceneGraph: async () => snapshot(),
+  pressKey: async (_target: string, key: string) => {
+    device.keys.push(key);
+    if (key === "Select" && device.selectWorks) {
+      device.folder = "Fixture folder";
+      device.focus = 0;
+    }
+    if (key === "Back" && device.backWorks) {
+      device.folder = "Your Files";
+      device.focus = device.restoreFocus ? 2 : 0;
+    }
+  },
+  waitForSceneGraphAssertion: async (_target: string, _message: string, assert: (xml: string) => void) => {
+    assert(snapshot());
+  },
+}));
+
+const noop = async () => {};
+const driver: AppFlowDriver = {
+  assertListHasItems: async () => 4,
+  authRefreshSmoke: noop,
+  focusLastListItem: noop,
+  focusListItemByIndex: async (_target, _nodeName, index) => { device.focus = index; },
+  openHomeItem: noop,
+  playbackTypeSmoke: noop,
+  imageRenderSmoke: noop,
+  playerUiSmoke: noop,
+  resetAuthState: noop,
+  returnToHomeScreen: noop,
+  waitForAnyRouteScreenVisible: async () => "filesScreen",
+  waitForAuthReady: noop,
+  waitForBootstrapScreen: async () => "filesScreen",
+  waitForRouteScreenVisible: noop,
+};
+const options = { profile: "synthetic", mediaType: "movie", startFromChoice: "continue", filesFolderName: "Fixture folder", filesFolderIndex: 2 } as const;
+const run = () => runAppFlow("files", { target: "synthetic", artifactDir: "unused" }, options, driver);
+
+describe("Files navigation proof", () => {
+  beforeEach(() => {
+    Object.assign(device, { folder: "Your Files", focus: 2, focusAttribute: "focusItem", selectWorks: true, backWorks: true, restoreFocus: true, keys: [] });
+  });
+
+  it("requires a prepared fixture before sending keys", async () => {
+    await expect(runAppFlow("files", { target: "synthetic", artifactDir: "unused" }, { profile: "synthetic", mediaType: "movie", startFromChoice: "continue" }, driver)).rejects.toThrow("FILES_FOLDER_NAME");
+    expect(device.keys).toEqual([]);
+  });
+
+  it("passes only after the selected folder opens and Back restores parent and focus", async () => {
+    await run();
+    expect(device.keys).toEqual(["Select", "Back"]);
+  });
+
+  it("rejects no-op Select even when Files remains visible and a hidden screen has the destination title", async () => {
+    device.selectWorks = false;
+    await expect(run()).rejects.toThrow();
+    expect(device.keys).toEqual(["Select"]);
+  });
+
+  it("accepts the inspector's itemFocused field", async () => {
+    device.focusAttribute = "itemFocused";
+    await run();
+    expect(device.keys).toEqual(["Select", "Back"]);
+  });
+
+  it("rejects missing focus evidence even for fixture index zero", async () => {
+    device.focusAttribute = "";
+    await expect(runAppFlow("files", { target: "synthetic", artifactDir: "unused" }, { ...options, filesFolderIndex: 0 }, driver)).rejects.toThrow();
+    expect(device.keys).toEqual([]);
+  });
+
+  it("rejects no-op Back", async () => {
+    device.backWorks = false;
+    await expect(run()).rejects.toThrow();
+  });
+
+  it("rejects Back that restores the parent but loses selection", async () => {
+    device.restoreFocus = false;
+    await expect(run()).rejects.toThrow("fixture row");
+  });
+});

--- a/test/live-test/files-flow.test.ts
+++ b/test/live-test/files-flow.test.ts
@@ -8,12 +8,27 @@ const device = vi.hoisted(() => ({
   selectWorks: true,
   backWorks: true,
   restoreFocus: true,
+  extraHiddenFilesScreen: false,
   keys: [] as string[],
 }));
 
 function snapshot(): string {
   const focus = device.focusAttribute ? `${device.focusAttribute}="${device.focus}"` : "";
-  return `<Scene><SearchScreen visible="false"><Label name="titleLabel" text="Fixture folder" /></SearchScreen><FilesScreen name="filesScreen" visible="true"><ScreenHeader><Label name="titleLabel" text="${device.folder}" /></ScreenHeader><LoadingIndicator name="loading" visible="false" /><MarkupList name="fileList" visible="true" ${focus} count="4" /></FilesScreen></Scene>`;
+  return [
+    ...(device.extraHiddenFilesScreen
+      ? ['<FilesScreen _psn="1" _sn="20" name="filesScreen" visible="false"/>', '<Label _psn="20" _sn="21" name="titleLabel" text="Stale"/>']
+      : []),
+    '<SearchScreen _psn="1" _sn="2" name="searchScreen" visible="false"/>',
+    '<Label _psn="2" _sn="3" name="titleLabel" text="Fixture folder"/>',
+    '<FilesScreen _psn="1" _sn="4" name="filesScreen"/>',
+    '<ScreenHeader _psn="4" _sn="5" name="screenHeader"/>',
+    `<Label _psn="5" _sn="6" name="titleLabel" text="${device.folder}"/>`,
+    '<Rectangle _sn="99" visible="false"/>',
+    '<LoadingIndicator _psn="4" _sn="7" name="loading" visible="false"/>',
+    `<MarkupList _psn="4" _sn="8" name="fileList" ${focus} count="4"/>`,
+    '<HistoryScreen _psn="1" _sn="9" name="historyScreen" visible="false"/>',
+    '<Label _psn="9" _sn="10" name="titleLabel" text="History"/>',
+  ].join("\n");
 }
 
 vi.mock("../../scripts/live-test/rokit-device.ts", () => ({
@@ -56,7 +71,7 @@ const run = () => runAppFlow("files", { target: "synthetic", artifactDir: "unuse
 
 describe("Files navigation proof", () => {
   beforeEach(() => {
-    Object.assign(device, { folder: "Your Files", focus: 2, focusAttribute: "focusItem", selectWorks: true, backWorks: true, restoreFocus: true, keys: [] });
+    Object.assign(device, { folder: "Your Files", focus: 2, focusAttribute: "focusItem", selectWorks: true, backWorks: true, restoreFocus: true, extraHiddenFilesScreen: false, keys: [] });
   });
 
   it("requires a prepared fixture before sending keys", async () => {
@@ -73,6 +88,12 @@ describe("Files navigation proof", () => {
     device.selectWorks = false;
     await expect(run()).rejects.toThrow();
     expect(device.keys).toEqual(["Select"]);
+  });
+
+  it("scopes to the topmost visible Files screen when a hidden one precedes it", async () => {
+    device.extraHiddenFilesScreen = true;
+    await run();
+    expect(device.keys).toEqual(["Select", "Back"]);
   });
 
   it("accepts the inspector's itemFocused field", async () => {

--- a/test/live-test/flow-options.test.ts
+++ b/test/live-test/flow-options.test.ts
@@ -13,18 +13,27 @@ describe("live-test flow options", () => {
   it("reads image and history fixtures from environment", () => {
     vi.stubEnv("PUTIO_CLI_PROFILE", "fixture-profile");
     vi.stubEnv("IMAGE_CONTENT_ID", "image-123");
+    vi.stubEnv("FILES_FOLDER_NAME", "Fixture folder");
+    vi.stubEnv("FILES_FOLDER_INDEX", "2");
     vi.stubEnv("HISTORY_EXPECTED_TEXT", "transfer_completed");
 
     expect(appFlowOptionsFromArgs(["video-123", "audio-123", "subtitle-123"])).toMatchObject({
       profile: "fixture-profile",
       playbackContentId: "video-123",
       imageContentId: "image-123",
+      filesFolderName: "Fixture folder",
+      filesFolderIndex: 2,
       audioContentId: "audio-123",
       subtitleContentId: "subtitle-123",
       historyExpectedText: "transfer_completed",
       mediaType: "movie",
       startFromChoice: "continue",
     });
+  });
+
+  it.each(["-1", "1.5", "NaN", "Infinity", "9007199254740992"])("rejects invalid folder index %s", (value) => {
+    vi.stubEnv("FILES_FOLDER_INDEX", value);
+    expect(() => appFlowOptionsFromArgs([])).toThrow("FILES_FOLDER_INDEX");
   });
 
   it("supports beginning playback starts", () => {


### PR DESCRIPTION
The Files live-test flow could pass when Select did nothing because it only checked that the Files screen remained visible. Require an explicit prepared folder fixture, assert its destination title after Select, and assert the original folder and selected row after Back, scoped to the visible Files screen and requiring actual focus evidence from either known inspector field.

The Roku inspector returns a flat list of self-closing tags linked by `_sn`/`_psn` serials rather than nested XML, so the Files subtree is collected by following those serials from the topmost visible `FilesScreen`. Leaf nodes without `_psn` stay inside the current subtree.

Device acceptance on a Roku Stick 3500X, Roku OS 11.0.0.4195, at this head, using root folder `putio-ios-harness` at row 2 of the test account:

- `FILES_FOLDER_NAME="putio-ios-harness" FILES_FOLDER_INDEX=2 FLOWS=auth,files pnpm roku live-test-flow` passed: Select changed the header to the fixture name and Back restored `Your Files` with `focusItem="2"`.
- `pnpm roku live-test-flow-smoke` with the same fixture passed end to end.

`pnpm verify` passed with 76 tests; synthetic regressions reject no-op Select, no-op Back, lost or missing focus, a destination title on a hidden screen, and a stale hidden Files screen preceding the visible one. Independent review is clean.