### PR TITLE
chore(tooling): adopt compatible Roku harness releases

### DIFF
--- a/.vref/index.html
+++ b/.vref/index.html
@@ -110,33 +110,33 @@
     outline-offset: 3px;
   }
   .nav-btn:has(.filter-control:checked) { color: #15130A; background: var(--yellow); font-weight: 600; }
-  .container:has(#filter-group-dialogs:checked) #gallery .card:not([data-group="dialogs"]) { display: none; }
-  .container:has(#filter-group-lab-components:checked) #gallery .card:not([data-group="lab-components"]) { display: none; }
-  .container:has(#filter-group-main-pages:checked) #gallery .card:not([data-group="main-pages"]) { display: none; }
-  .container:has(#filter-group-player:checked) #gallery .card:not([data-group="player"]) { display: none; }
-  .container:has(#filter-group-search:checked) #gallery .card:not([data-group="search"]) { display: none; }
-  .container:has(#filter-tag-app-dialog:checked) #gallery .card:not([data-tags~="app-dialog"]) { display: none; }
-  .container:has(#filter-tag-dialog:checked) #gallery .card:not([data-tags~="dialog"]) { display: none; }
-  .container:has(#filter-tag-empty:checked) #gallery .card:not([data-tags~="empty"]) { display: none; }
-  .container:has(#filter-tag-files:checked) #gallery .card:not([data-tags~="files"]) { display: none; }
-  .container:has(#filter-tag-focus:checked) #gallery .card:not([data-tags~="focus"]) { display: none; }
-  .container:has(#filter-tag-gt-america:checked) #gallery .card:not([data-tags~="gt-america"]) { display: none; }
-  .container:has(#filter-tag-home:checked) #gallery .card:not([data-tags~="home"]) { display: none; }
-  .container:has(#filter-tag-keyboard:checked) #gallery .card:not([data-tags~="keyboard"]) { display: none; }
-  .container:has(#filter-tag-lab:checked) #gallery .card:not([data-tags~="lab"]) { display: none; }
-  .container:has(#filter-tag-list:checked) #gallery .card:not([data-tags~="list"]) { display: none; }
-  .container:has(#filter-tag-player:checked) #gallery .card:not([data-tags~="player"]) { display: none; }
-  .container:has(#filter-tag-progress:checked) #gallery .card:not([data-tags~="progress"]) { display: none; }
-  .container:has(#filter-tag-search:checked) #gallery .card:not([data-tags~="search"]) { display: none; }
-  .container:has(#filter-tag-subtitles:checked) #gallery .card:not([data-tags~="subtitles"]) { display: none; }
-  .container:has(#filter-tag-track-menu:checked) #gallery .card:not([data-tags~="track-menu"]) { display: none; }
+  .container:has(#filter-group-value-004400690061006c006f00670073:checked) #gallery .card:not([data-group="value-004400690061006c006f00670073"]) { display: none; }
+  .container:has(#filter-group-value-004c0061006200200063006f006d0070006f006e0065006e00740073:checked) #gallery .card:not([data-group="value-004c0061006200200063006f006d0070006f006e0065006e00740073"]) { display: none; }
+  .container:has(#filter-group-value-004d00610069006e002000700061006700650073:checked) #gallery .card:not([data-group="value-004d00610069006e002000700061006700650073"]) { display: none; }
+  .container:has(#filter-group-value-0050006c0061007900650072:checked) #gallery .card:not([data-group="value-0050006c0061007900650072"]) { display: none; }
+  .container:has(#filter-group-value-005300650061007200630068:checked) #gallery .card:not([data-group="value-005300650061007200630068"]) { display: none; }
+  .container:has(#filter-tag-value-006100700070002d006400690061006c006f0067:checked) #gallery .card:not([data-tags~="value-006100700070002d006400690061006c006f0067"]) { display: none; }
+  .container:has(#filter-tag-value-006400690061006c006f0067:checked) #gallery .card:not([data-tags~="value-006400690061006c006f0067"]) { display: none; }
+  .container:has(#filter-tag-value-0065006d007000740079:checked) #gallery .card:not([data-tags~="value-0065006d007000740079"]) { display: none; }
+  .container:has(#filter-tag-value-00660069006c00650073:checked) #gallery .card:not([data-tags~="value-00660069006c00650073"]) { display: none; }
+  .container:has(#filter-tag-value-0066006f006300750073:checked) #gallery .card:not([data-tags~="value-0066006f006300750073"]) { display: none; }
+  .container:has(#filter-tag-value-00670074002d0061006d00650072006900630061:checked) #gallery .card:not([data-tags~="value-00670074002d0061006d00650072006900630061"]) { display: none; }
+  .container:has(#filter-tag-value-0068006f006d0065:checked) #gallery .card:not([data-tags~="value-0068006f006d0065"]) { display: none; }
+  .container:has(#filter-tag-value-006b006500790062006f006100720064:checked) #gallery .card:not([data-tags~="value-006b006500790062006f006100720064"]) { display: none; }
+  .container:has(#filter-tag-value-006c00610062:checked) #gallery .card:not([data-tags~="value-006c00610062"]) { display: none; }
+  .container:has(#filter-tag-value-006c006900730074:checked) #gallery .card:not([data-tags~="value-006c006900730074"]) { display: none; }
+  .container:has(#filter-tag-value-0070006c0061007900650072:checked) #gallery .card:not([data-tags~="value-0070006c0061007900650072"]) { display: none; }
+  .container:has(#filter-tag-value-00700072006f00670072006500730073:checked) #gallery .card:not([data-tags~="value-00700072006f00670072006500730073"]) { display: none; }
+  .container:has(#filter-tag-value-007300650061007200630068:checked) #gallery .card:not([data-tags~="value-007300650061007200630068"]) { display: none; }
+  .container:has(#filter-tag-value-007300750062007400690074006c00650073:checked) #gallery .card:not([data-tags~="value-007300750062007400690074006c00650073"]) { display: none; }
+  .container:has(#filter-tag-value-0074007200610063006b002d006d0065006e0075:checked) #gallery .card:not([data-tags~="value-0074007200610063006b002d006d0065006e0075"]) { display: none; }
   .results-count {
     font-size: 11px;
     color: var(--solid);
     margin-bottom: 16px;
     font-family: 'Berkeley Mono', ui-monospace, 'SF Mono', Menlo, monospace;
   }
-  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 340px), 1fr)); gap: 18px; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 340px), 1fr)); align-items: start; gap: 18px; }
   .card {
     display: block;
     text-decoration: none;
@@ -152,11 +152,13 @@
     display: block;
     width: 100%;
     aspect-ratio: 16 / 9;
-    object-fit: cover;
+    object-fit: contain;
     background: #000;
     outline: 1px solid rgba(255,255,255,0.08);
     outline-offset: -1px;
   }
+  .card[data-orientation="portrait"] .preview { aspect-ratio: 3 / 4; }
+  .card[data-orientation="square"] .preview { aspect-ratio: 1; }
   .card-body { display: flex; align-items: flex-start; gap: 10px; padding: 14px; }
   .item-info { flex: 1; min-width: 0; }
   .item-name { font-size: 14px; font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
@@ -292,16 +294,16 @@
   <div class="filters">
     <div class="filter-row">
       <span class="filter-label">Group</span>
-      <div class="filter-group"><label class="nav-btn" data-filter-group="group" data-filter-value="all"><input class="filter-control" type="radio" name="filter-group" id="filter-group-all" checked><span>All</span></label><label class="nav-btn" data-filter-group="group" data-filter-value="dialogs"><input class="filter-control" type="radio" name="filter-group" id="filter-group-dialogs"><span>Dialogs</span></label><label class="nav-btn" data-filter-group="group" data-filter-value="lab-components"><input class="filter-control" type="radio" name="filter-group" id="filter-group-lab-components"><span>Lab components</span></label><label class="nav-btn" data-filter-group="group" data-filter-value="main-pages"><input class="filter-control" type="radio" name="filter-group" id="filter-group-main-pages"><span>Main pages</span></label><label class="nav-btn" data-filter-group="group" data-filter-value="player"><input class="filter-control" type="radio" name="filter-group" id="filter-group-player"><span>Player</span></label><label class="nav-btn" data-filter-group="group" data-filter-value="search"><input class="filter-control" type="radio" name="filter-group" id="filter-group-search"><span>Search</span></label></div>
+      <div class="filter-group"><label class="nav-btn" data-filter-group="group" data-filter-value="all"><input class="filter-control" type="radio" name="filter-group" id="filter-group-all" checked><span>All</span></label><label class="nav-btn" data-filter-group="group" data-filter-value="value-004400690061006c006f00670073"><input class="filter-control" type="radio" name="filter-group" id="filter-group-value-004400690061006c006f00670073"><span>Dialogs</span></label><label class="nav-btn" data-filter-group="group" data-filter-value="value-004c0061006200200063006f006d0070006f006e0065006e00740073"><input class="filter-control" type="radio" name="filter-group" id="filter-group-value-004c0061006200200063006f006d0070006f006e0065006e00740073"><span>Lab components</span></label><label class="nav-btn" data-filter-group="group" data-filter-value="value-004d00610069006e002000700061006700650073"><input class="filter-control" type="radio" name="filter-group" id="filter-group-value-004d00610069006e002000700061006700650073"><span>Main pages</span></label><label class="nav-btn" data-filter-group="group" data-filter-value="value-0050006c0061007900650072"><input class="filter-control" type="radio" name="filter-group" id="filter-group-value-0050006c0061007900650072"><span>Player</span></label><label class="nav-btn" data-filter-group="group" data-filter-value="value-005300650061007200630068"><input class="filter-control" type="radio" name="filter-group" id="filter-group-value-005300650061007200630068"><span>Search</span></label></div>
     </div>
     <div class="filter-row">
       <span class="filter-label">Tag</span>
-      <div class="filter-group"><label class="nav-btn" data-filter-group="tag" data-filter-value="all"><input class="filter-control" type="radio" name="filter-tag" id="filter-tag-all" checked><span>All</span></label><label class="nav-btn" data-filter-group="tag" data-filter-value="app-dialog"><input class="filter-control" type="radio" name="filter-tag" id="filter-tag-app-dialog"><span>app-dialog</span></label><label class="nav-btn" data-filter-group="tag" data-filter-value="dialog"><input class="filter-control" type="radio" name="filter-tag" id="filter-tag-dialog"><span>dialog</span></label><label class="nav-btn" data-filter-group="tag" data-filter-value="empty"><input class="filter-control" type="radio" name="filter-tag" id="filter-tag-empty"><span>empty</span></label><label class="nav-btn" data-filter-group="tag" data-filter-value="files"><input class="filter-control" type="radio" name="filter-tag" id="filter-tag-files"><span>files</span></label><label class="nav-btn" data-filter-group="tag" data-filter-value="focus"><input class="filter-control" type="radio" name="filter-tag" id="filter-tag-focus"><span>focus</span></label><label class="nav-btn" data-filter-group="tag" data-filter-value="gt-america"><input class="filter-control" type="radio" name="filter-tag" id="filter-tag-gt-america"><span>gt-america</span></label><label class="nav-btn" data-filter-group="tag" data-filter-value="home"><input class="filter-control" type="radio" name="filter-tag" id="filter-tag-home"><span>home</span></label><label class="nav-btn" data-filter-group="tag" data-filter-value="keyboard"><input class="filter-control" type="radio" name="filter-tag" id="filter-tag-keyboard"><span>keyboard</span></label><label class="nav-btn" data-filter-group="tag" data-filter-value="lab"><input class="filter-control" type="radio" name="filter-tag" id="filter-tag-lab"><span>lab</span></label><label class="nav-btn" data-filter-group="tag" data-filter-value="list"><input class="filter-control" type="radio" name="filter-tag" id="filter-tag-list"><span>list</span></label><label class="nav-btn" data-filter-group="tag" data-filter-value="player"><input class="filter-control" type="radio" name="filter-tag" id="filter-tag-player"><span>player</span></label><label class="nav-btn" data-filter-group="tag" data-filter-value="progress"><input class="filter-control" type="radio" name="filter-tag" id="filter-tag-progress"><span>progress</span></label><label class="nav-btn" data-filter-group="tag" data-filter-value="search"><input class="filter-control" type="radio" name="filter-tag" id="filter-tag-search"><span>search</span></label><label class="nav-btn" data-filter-group="tag" data-filter-value="subtitles"><input class="filter-control" type="radio" name="filter-tag" id="filter-tag-subtitles"><span>subtitles</span></label><label class="nav-btn" data-filter-group="tag" data-filter-value="track-menu"><input class="filter-control" type="radio" name="filter-tag" id="filter-tag-track-menu"><span>track-menu</span></label></div>
+      <div class="filter-group"><label class="nav-btn" data-filter-group="tag" data-filter-value="all"><input class="filter-control" type="radio" name="filter-tag" id="filter-tag-all" checked><span>All</span></label><label class="nav-btn" data-filter-group="tag" data-filter-value="value-006100700070002d006400690061006c006f0067"><input class="filter-control" type="radio" name="filter-tag" id="filter-tag-value-006100700070002d006400690061006c006f0067"><span>app-dialog</span></label><label class="nav-btn" data-filter-group="tag" data-filter-value="value-006400690061006c006f0067"><input class="filter-control" type="radio" name="filter-tag" id="filter-tag-value-006400690061006c006f0067"><span>dialog</span></label><label class="nav-btn" data-filter-group="tag" data-filter-value="value-0065006d007000740079"><input class="filter-control" type="radio" name="filter-tag" id="filter-tag-value-0065006d007000740079"><span>empty</span></label><label class="nav-btn" data-filter-group="tag" data-filter-value="value-00660069006c00650073"><input class="filter-control" type="radio" name="filter-tag" id="filter-tag-value-00660069006c00650073"><span>files</span></label><label class="nav-btn" data-filter-group="tag" data-filter-value="value-0066006f006300750073"><input class="filter-control" type="radio" name="filter-tag" id="filter-tag-value-0066006f006300750073"><span>focus</span></label><label class="nav-btn" data-filter-group="tag" data-filter-value="value-00670074002d0061006d00650072006900630061"><input class="filter-control" type="radio" name="filter-tag" id="filter-tag-value-00670074002d0061006d00650072006900630061"><span>gt-america</span></label><label class="nav-btn" data-filter-group="tag" data-filter-value="value-0068006f006d0065"><input class="filter-control" type="radio" name="filter-tag" id="filter-tag-value-0068006f006d0065"><span>home</span></label><label class="nav-btn" data-filter-group="tag" data-filter-value="value-006b006500790062006f006100720064"><input class="filter-control" type="radio" name="filter-tag" id="filter-tag-value-006b006500790062006f006100720064"><span>keyboard</span></label><label class="nav-btn" data-filter-group="tag" data-filter-value="value-006c00610062"><input class="filter-control" type="radio" name="filter-tag" id="filter-tag-value-006c00610062"><span>lab</span></label><label class="nav-btn" data-filter-group="tag" data-filter-value="value-006c006900730074"><input class="filter-control" type="radio" name="filter-tag" id="filter-tag-value-006c006900730074"><span>list</span></label><label class="nav-btn" data-filter-group="tag" data-filter-value="value-0070006c0061007900650072"><input class="filter-control" type="radio" name="filter-tag" id="filter-tag-value-0070006c0061007900650072"><span>player</span></label><label class="nav-btn" data-filter-group="tag" data-filter-value="value-00700072006f00670072006500730073"><input class="filter-control" type="radio" name="filter-tag" id="filter-tag-value-00700072006f00670072006500730073"><span>progress</span></label><label class="nav-btn" data-filter-group="tag" data-filter-value="value-007300650061007200630068"><input class="filter-control" type="radio" name="filter-tag" id="filter-tag-value-007300650061007200630068"><span>search</span></label><label class="nav-btn" data-filter-group="tag" data-filter-value="value-007300750062007400690074006c00650073"><input class="filter-control" type="radio" name="filter-tag" id="filter-tag-value-007300750062007400690074006c00650073"><span>subtitles</span></label><label class="nav-btn" data-filter-group="tag" data-filter-value="value-0074007200610063006b002d006d0065006e0075"><input class="filter-control" type="radio" name="filter-tag" id="filter-tag-value-0074007200610063006b002d006d0065006e0075"><span>track-menu</span></label></div>
     </div>
   </div>
   <div class="results-count">19 references &middot; Updated Jul 25, 2026</div>
   <div class="grid" id="gallery">
-    <a class="card" href="screenshots/roku-720p/auth.jpg" aria-label="Auth screenshot" data-card data-title="Auth" data-platform="roku" data-group="main-pages" data-tags="auth activation-code gt-america">
+    <a class="card" href="screenshots/roku-720p/auth.jpg" aria-label="Auth screenshot" data-card data-title="Auth" data-platform="value-0052006f006b0075" data-group="value-004d00610069006e002000700061006700650073" data-tags="value-0061007500740068 value-00610063007400690076006100740069006f006e002d0063006f00640065 value-00670074002d0061006d00650072006900630061" data-orientation="landscape">
       <img class="preview" src="screenshots/roku-720p/auth.jpg" alt="" loading="lazy">
       <div class="card-body">
         <div class="item-info">
@@ -311,7 +313,7 @@
         </div>
       </div>
     </a>
-    <a class="card" href="screenshots/roku-720p/home.jpg" aria-label="Home screenshot" data-card data-title="Home" data-platform="roku" data-group="main-pages" data-tags="home navigation gt-america">
+    <a class="card" href="screenshots/roku-720p/home.jpg" aria-label="Home screenshot" data-card data-title="Home" data-platform="value-0052006f006b0075" data-group="value-004d00610069006e002000700061006700650073" data-tags="value-0068006f006d0065 value-006e0061007600690067006100740069006f006e value-00670074002d0061006d00650072006900630061" data-orientation="landscape">
       <img class="preview" src="screenshots/roku-720p/home.jpg" alt="" loading="lazy">
       <div class="card-body">
         <div class="item-info">
@@ -321,7 +323,7 @@
         </div>
       </div>
     </a>
-    <a class="card" href="screenshots/roku-720p/files.jpg" aria-label="Files screenshot" data-card data-title="Files" data-platform="roku" data-group="main-pages" data-tags="files list focus gt-america">
+    <a class="card" href="screenshots/roku-720p/files.jpg" aria-label="Files screenshot" data-card data-title="Files" data-platform="value-0052006f006b0075" data-group="value-004d00610069006e002000700061006700650073" data-tags="value-00660069006c00650073 value-006c006900730074 value-0066006f006300750073 value-00670074002d0061006d00650072006900630061" data-orientation="landscape">
       <img class="preview" src="screenshots/roku-720p/files.jpg" alt="" loading="lazy">
       <div class="card-body">
         <div class="item-info">
@@ -331,7 +333,7 @@
         </div>
       </div>
     </a>
-    <a class="card" href="screenshots/roku-720p/history.jpg" aria-label="History screenshot" data-card data-title="History" data-platform="roku" data-group="main-pages" data-tags="history list focus gt-america">
+    <a class="card" href="screenshots/roku-720p/history.jpg" aria-label="History screenshot" data-card data-title="History" data-platform="value-0052006f006b0075" data-group="value-004d00610069006e002000700061006700650073" data-tags="value-0068006900730074006f00720079 value-006c006900730074 value-0066006f006300750073 value-00670074002d0061006d00650072006900630061" data-orientation="landscape">
       <img class="preview" src="screenshots/roku-720p/history.jpg" alt="" loading="lazy">
       <div class="card-body">
         <div class="item-info">
@@ -341,7 +343,7 @@
         </div>
       </div>
     </a>
-    <a class="card" href="screenshots/roku-720p/image.jpg" aria-label="Image viewer screenshot" data-card data-title="Image viewer" data-platform="roku" data-group="main-pages" data-tags="image viewer scale-to-fit gt-america">
+    <a class="card" href="screenshots/roku-720p/image.jpg" aria-label="Image viewer screenshot" data-card data-title="Image viewer" data-platform="value-0052006f006b0075" data-group="value-004d00610069006e002000700061006700650073" data-tags="value-0069006d006100670065 value-007600690065007700650072 value-007300630061006c0065002d0074006f002d006600690074 value-00670074002d0061006d00650072006900630061" data-orientation="landscape">
       <img class="preview" src="screenshots/roku-720p/image.jpg" alt="" loading="lazy">
       <div class="card-body">
         <div class="item-info">
@@ -351,7 +353,7 @@
         </div>
       </div>
     </a>
-    <a class="card" href="screenshots/roku-720p/file-delete-dialog.jpg" aria-label="File delete dialog screenshot" data-card data-title="File delete dialog" data-platform="roku" data-group="dialogs" data-tags="files dialog destructive gt-america">
+    <a class="card" href="screenshots/roku-720p/file-delete-dialog.jpg" aria-label="File delete dialog screenshot" data-card data-title="File delete dialog" data-platform="value-0052006f006b0075" data-group="value-004400690061006c006f00670073" data-tags="value-00660069006c00650073 value-006400690061006c006f0067 value-00640065007300740072007500630074006900760065 value-00670074002d0061006d00650072006900630061" data-orientation="landscape">
       <img class="preview" src="screenshots/roku-720p/file-delete-dialog.jpg" alt="" loading="lazy">
       <div class="card-body">
         <div class="item-info">
@@ -361,7 +363,7 @@
         </div>
       </div>
     </a>
-    <a class="card" href="screenshots/roku-720p/search-empty.jpg" aria-label="Search empty screenshot" data-card data-title="Search empty" data-platform="roku" data-group="main-pages" data-tags="search keyboard empty gt-america">
+    <a class="card" href="screenshots/roku-720p/search-empty.jpg" aria-label="Search empty screenshot" data-card data-title="Search empty" data-platform="value-0052006f006b0075" data-group="value-004d00610069006e002000700061006700650073" data-tags="value-007300650061007200630068 value-006b006500790062006f006100720064 value-0065006d007000740079 value-00670074002d0061006d00650072006900630061" data-orientation="landscape">
       <img class="preview" src="screenshots/roku-720p/search-empty.jpg" alt="" loading="lazy">
       <div class="card-body">
         <div class="item-info">
@@ -371,7 +373,7 @@
         </div>
       </div>
     </a>
-    <a class="card" href="screenshots/roku-720p/search-no-results.jpg" aria-label="Search no results screenshot" data-card data-title="Search no results" data-platform="roku" data-group="search" data-tags="search keyboard empty gt-america">
+    <a class="card" href="screenshots/roku-720p/search-no-results.jpg" aria-label="Search no results screenshot" data-card data-title="Search no results" data-platform="value-0052006f006b0075" data-group="value-005300650061007200630068" data-tags="value-007300650061007200630068 value-006b006500790062006f006100720064 value-0065006d007000740079 value-00670074002d0061006d00650072006900630061" data-orientation="landscape">
       <img class="preview" src="screenshots/roku-720p/search-no-results.jpg" alt="" loading="lazy">
       <div class="card-body">
         <div class="item-info">
@@ -381,7 +383,7 @@
         </div>
       </div>
     </a>
-    <a class="card" href="screenshots/roku-720p/search-results.jpg" aria-label="Search results screenshot" data-card data-title="Search results" data-platform="roku" data-group="search" data-tags="search keyboard gt-america">
+    <a class="card" href="screenshots/roku-720p/search-results.jpg" aria-label="Search results screenshot" data-card data-title="Search results" data-platform="value-0052006f006b0075" data-group="value-005300650061007200630068" data-tags="value-007300650061007200630068 value-006b006500790062006f006100720064 value-00670074002d0061006d00650072006900630061" data-orientation="landscape">
       <img class="preview" src="screenshots/roku-720p/search-results.jpg" alt="" loading="lazy">
       <div class="card-body">
         <div class="item-info">
@@ -391,7 +393,7 @@
         </div>
       </div>
     </a>
-    <a class="card" href="screenshots/roku-720p/search-result-focused.jpg" aria-label="Search result focused screenshot" data-card data-title="Search result focused" data-platform="roku" data-group="search" data-tags="search focus gt-america">
+    <a class="card" href="screenshots/roku-720p/search-result-focused.jpg" aria-label="Search result focused screenshot" data-card data-title="Search result focused" data-platform="value-0052006f006b0075" data-group="value-005300650061007200630068" data-tags="value-007300650061007200630068 value-0066006f006300750073 value-00670074002d0061006d00650072006900630061" data-orientation="landscape">
       <img class="preview" src="screenshots/roku-720p/search-result-focused.jpg" alt="" loading="lazy">
       <div class="card-body">
         <div class="item-info">
@@ -401,7 +403,7 @@
         </div>
       </div>
     </a>
-    <a class="card" href="screenshots/roku-720p/settings.jpg" aria-label="Settings screenshot" data-card data-title="Settings" data-platform="roku" data-group="main-pages" data-tags="settings list device gt-america">
+    <a class="card" href="screenshots/roku-720p/settings.jpg" aria-label="Settings screenshot" data-card data-title="Settings" data-platform="value-0052006f006b0075" data-group="value-004d00610069006e002000700061006700650073" data-tags="value-00730065007400740069006e00670073 value-006c006900730074 value-006400650076006900630065 value-00670074002d0061006d00650072006900630061" data-orientation="landscape">
       <img class="preview" src="screenshots/roku-720p/settings.jpg" alt="" loading="lazy">
       <div class="card-body">
         <div class="item-info">
@@ -411,7 +413,7 @@
         </div>
       </div>
     </a>
-    <a class="card" href="screenshots/roku-720p/exit-app-dialog.jpg" aria-label="Exit app dialog screenshot" data-card data-title="Exit app dialog" data-platform="roku" data-group="dialogs" data-tags="home dialog exit gt-america">
+    <a class="card" href="screenshots/roku-720p/exit-app-dialog.jpg" aria-label="Exit app dialog screenshot" data-card data-title="Exit app dialog" data-platform="value-0052006f006b0075" data-group="value-004400690061006c006f00670073" data-tags="value-0068006f006d0065 value-006400690061006c006f0067 value-0065007800690074 value-00670074002d0061006d00650072006900630061" data-orientation="landscape">
       <img class="preview" src="screenshots/roku-720p/exit-app-dialog.jpg" alt="" loading="lazy">
       <div class="card-body">
         <div class="item-info">
@@ -421,7 +423,7 @@
         </div>
       </div>
     </a>
-    <a class="card" href="screenshots/roku-720p/lab-app-dialog-empty.jpg" aria-label="Lab app dialog without message screenshot" data-card data-title="Lab app dialog without message" data-platform="roku" data-group="lab-components" data-tags="lab dialog app-dialog gt-america">
+    <a class="card" href="screenshots/roku-720p/lab-app-dialog-empty.jpg" aria-label="Lab app dialog without message screenshot" data-card data-title="Lab app dialog without message" data-platform="value-0052006f006b0075" data-group="value-004c0061006200200063006f006d0070006f006e0065006e00740073" data-tags="value-006c00610062 value-006400690061006c006f0067 value-006100700070002d006400690061006c006f0067 value-00670074002d0061006d00650072006900630061" data-orientation="landscape">
       <img class="preview" src="screenshots/roku-720p/lab-app-dialog-empty.jpg" alt="" loading="lazy">
       <div class="card-body">
         <div class="item-info">
@@ -431,7 +433,7 @@
         </div>
       </div>
     </a>
-    <a class="card" href="screenshots/roku-720p/lab-app-dialog-message.jpg" aria-label="Lab app dialog with message screenshot" data-card data-title="Lab app dialog with message" data-platform="roku" data-group="lab-components" data-tags="lab dialog app-dialog gt-america">
+    <a class="card" href="screenshots/roku-720p/lab-app-dialog-message.jpg" aria-label="Lab app dialog with message screenshot" data-card data-title="Lab app dialog with message" data-platform="value-0052006f006b0075" data-group="value-004c0061006200200063006f006d0070006f006e0065006e00740073" data-tags="value-006c00610062 value-006400690061006c006f0067 value-006100700070002d006400690061006c006f0067 value-00670074002d0061006d00650072006900630061" data-orientation="landscape">
       <img class="preview" src="screenshots/roku-720p/lab-app-dialog-message.jpg" alt="" loading="lazy">
       <div class="card-body">
         <div class="item-info">
@@ -441,7 +443,7 @@
         </div>
       </div>
     </a>
-    <a class="card" href="screenshots/roku-720p/player-audio-menu.jpg" aria-label="Player audio menu screenshot" data-card data-title="Player audio menu" data-platform="roku" data-group="player" data-tags="player track-menu audio gt-america">
+    <a class="card" href="screenshots/roku-720p/player-audio-menu.jpg" aria-label="Player audio menu screenshot" data-card data-title="Player audio menu" data-platform="value-0052006f006b0075" data-group="value-0050006c0061007900650072" data-tags="value-0070006c0061007900650072 value-0074007200610063006b002d006d0065006e0075 value-0061007500640069006f value-00670074002d0061006d00650072006900630061" data-orientation="landscape">
       <img class="preview" src="screenshots/roku-720p/player-audio-menu.jpg" alt="" loading="lazy">
       <div class="card-body">
         <div class="item-info">
@@ -451,7 +453,7 @@
         </div>
       </div>
     </a>
-    <a class="card" href="screenshots/roku-720p/player-progress.jpg" aria-label="Player progress screenshot" data-card data-title="Player progress" data-platform="roku" data-group="player" data-tags="player progress focus gt-america">
+    <a class="card" href="screenshots/roku-720p/player-progress.jpg" aria-label="Player progress screenshot" data-card data-title="Player progress" data-platform="value-0052006f006b0075" data-group="value-0050006c0061007900650072" data-tags="value-0070006c0061007900650072 value-00700072006f00670072006500730073 value-0066006f006300750073 value-00670074002d0061006d00650072006900630061" data-orientation="landscape">
       <img class="preview" src="screenshots/roku-720p/player-progress.jpg" alt="" loading="lazy">
       <div class="card-body">
         <div class="item-info">
@@ -461,7 +463,7 @@
         </div>
       </div>
     </a>
-    <a class="card" href="screenshots/roku-720p/player-subtitle-button.jpg" aria-label="Player subtitle button screenshot" data-card data-title="Player subtitle button" data-platform="roku" data-group="player" data-tags="player subtitles focus gt-america">
+    <a class="card" href="screenshots/roku-720p/player-subtitle-button.jpg" aria-label="Player subtitle button screenshot" data-card data-title="Player subtitle button" data-platform="value-0052006f006b0075" data-group="value-0050006c0061007900650072" data-tags="value-0070006c0061007900650072 value-007300750062007400690074006c00650073 value-0066006f006300750073 value-00670074002d0061006d00650072006900630061" data-orientation="landscape">
       <img class="preview" src="screenshots/roku-720p/player-subtitle-button.jpg" alt="" loading="lazy">
       <div class="card-body">
         <div class="item-info">
@@ -471,7 +473,7 @@
         </div>
       </div>
     </a>
-    <a class="card" href="screenshots/roku-720p/player-subtitle-menu.jpg" aria-label="Player subtitle menu screenshot" data-card data-title="Player subtitle menu" data-platform="roku" data-group="player" data-tags="player track-menu subtitles gt-america">
+    <a class="card" href="screenshots/roku-720p/player-subtitle-menu.jpg" aria-label="Player subtitle menu screenshot" data-card data-title="Player subtitle menu" data-platform="value-0052006f006b0075" data-group="value-0050006c0061007900650072" data-tags="value-0070006c0061007900650072 value-0074007200610063006b002d006d0065006e0075 value-007300750062007400690074006c00650073 value-00670074002d0061006d00650072006900630061" data-orientation="landscape">
       <img class="preview" src="screenshots/roku-720p/player-subtitle-menu.jpg" alt="" loading="lazy">
       <div class="card-body">
         <div class="item-info">
@@ -481,7 +483,7 @@
         </div>
       </div>
     </a>
-    <a class="card" href="screenshots/roku-720p/player-progress-focus.jpg" aria-label="Player progress after menu screenshot" data-card data-title="Player progress after menu" data-platform="roku" data-group="player" data-tags="player progress subtitles gt-america">
+    <a class="card" href="screenshots/roku-720p/player-progress-focus.jpg" aria-label="Player progress after menu screenshot" data-card data-title="Player progress after menu" data-platform="value-0052006f006b0075" data-group="value-0050006c0061007900650072" data-tags="value-0070006c0061007900650072 value-00700072006f00670072006500730073 value-007300750062007400690074006c00650073 value-00670074002d0061006d00650072006900630061" data-orientation="landscape">
       <img class="preview" src="screenshots/roku-720p/player-progress-focus.jpg" alt="" loading="lazy">
       <div class="card-body">
         <div class="item-info">

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "devDependencies": {
     "@phosphor-icons/core": "2.1.1",
     "@putdotio/design": "^3.0.0",
-    "@putdotio/rokit": "2.4.2",
-    "@putdotio/vref": "1.1.1",
+    "@putdotio/rokit": "2.4.6",
+    "@putdotio/vref": "1.2.4",
     "@resvg/resvg-js": "^2.6.2",
     "@rokucommunity/bslint": "0.8.44",
     "@types/node": "^26.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,26 +116,26 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       '@putdotio/rokit':
-        specifier: 2.4.2
-        version: 2.4.2(ioredis@5.10.1)
+        specifier: 2.4.6
+        version: 2.4.6(ioredis@5.10.1(supports-color@7.2.0))
       '@putdotio/vref':
-        specifier: 1.1.1
-        version: 1.1.1
+        specifier: 1.2.4
+        version: 1.2.4(ioredis@5.10.1(supports-color@7.2.0))
       '@resvg/resvg-js':
         specifier: ^2.6.2
         version: 2.6.2
       '@rokucommunity/bslint':
         specifier: 0.8.44
-        version: 0.8.44(brighterscript@0.73.0)
+        version: 0.8.44(brighterscript@0.73.0(supports-color@7.2.0))
       '@types/node':
         specifier: ^26.1.2
         version: 26.1.2
       brighterscript:
         specifier: 0.73.0
-        version: 0.73.0
+        version: 0.73.0(supports-color@7.2.0)
       brighterscript-formatter:
         specifier: 1.8.1
-        version: 1.8.1
+        version: 1.8.1(supports-color@7.2.0)
       sst:
         specifier: ^4.17.1
         version: 4.17.1
@@ -216,18 +216,18 @@ packages:
     resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
     engines: {node: '>=18.0.0'}
 
-  '@effect/platform-node-shared@4.0.0-beta.101':
-    resolution: {integrity: sha512-g4L7XiyJSNJLJVhlslyg2zBCQsoKQf1y1gd+Yfd+3wD9ymC+m7ymbd/5FGqnT1aXV6E2AwRr4D/R1eyRUikvWQ==}
+  '@effect/platform-node-shared@4.0.0-beta.107':
+    resolution: {integrity: sha512-y6BqcRi86BfTJv+tvDrob4ozYVHxxlHYcn/zIQqZjXI9CvKnkgD6ng+38G1o45c4f2ucU+6HRI9POCmFdMoVGA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      effect: ^4.0.0-beta.101
+      effect: ^4.0.0-beta.107
 
-  '@effect/platform-node@4.0.0-beta.97':
-    resolution: {integrity: sha512-Vd40VLh+Y08Bs37KWtbe9AgO2+t3RKZKGX9YC6ZKAcswu4tXR3CwSI7V2MN+GgS+ez/GLmqH1WrzDDlaIAxKPA==}
+  '@effect/platform-node@4.0.0-beta.107':
+    resolution: {integrity: sha512-k+6YNbV4Ck0L6YXtlgkvEnuP5tlxWD8EeWOrpn46PDqbGEwt4ONpRltTwm3tn2cyBXD0i+2P11cUH/6sdFagTA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      effect: ^4.0.0-beta.97
-      ioredis: ^5.7.0
+      effect: ^4.0.0-beta.107
+      ioredis: '>=5.7.0 <6.0.0'
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -313,14 +313,14 @@ packages:
   '@putdotio/design@3.0.0':
     resolution: {integrity: sha512-C4m/v7Z4LJUEXV8VGcL3Owb+16yyCqDZU15+7fj5c5S82UsuXDztW383liQEb68NlQItcj03AJldfD5XOkIqKQ==}
 
-  '@putdotio/rokit@2.4.2':
-    resolution: {integrity: sha512-GVSiqnrAezbWxSQnlSMv/7byLTowcowLw0L5gltsGSWNo65t0EJW8GQ9iMq7hE+x6bXgNEMKbp03c5l47j4czA==}
-    engines: {node: '>=24.18.0'}
+  '@putdotio/rokit@2.4.6':
+    resolution: {integrity: sha512-GbtKWCTBvD6blyldskg3fPRnZTbpt0RA6DQGBtWkKk2f5ppZ6DZ2agTF/KNsnHVXgQ43qDBuNgSE7PEcorJt7g==}
+    engines: {node: '>=24.19.0'}
     hasBin: true
 
-  '@putdotio/vref@1.1.1':
-    resolution: {integrity: sha512-0g2fzA3oHQ5qcYD71B0Z4PgihzPHWKRb5JqGu8FmjKsB5nO5y/br3Z2b9LpApgn7eyodmXN2viZ47eKf/6SLXQ==}
-    engines: {node: '>=24.18.0'}
+  '@putdotio/vref@1.2.4':
+    resolution: {integrity: sha512-7yRxPnQEDZdggIp1Ji2IUEqrybY4dS7IxTUaUYXDcZDfBffMlsxEAzQjR2/Y36MAwdia0Q1NWXDVXqCQAiPDHQ==}
+    engines: {node: '>=24.19.0'}
     hasBin: true
 
   '@resvg/resvg-js-android-arm-eabi@2.6.2':
@@ -414,6 +414,9 @@ packages:
 
   '@rokucommunity/logger@0.4.0':
     resolution: {integrity: sha512-t6Div2Cf5/gEACtdU2IYLE+x3GFT90PA5X94uOYl7F1Gwow6bmapuUtjybeAxQWfFq1aDfXG8ZF+WO1wRoQfQQ==}
+
+  '@rokucommunity/logger@0.4.2':
+    resolution: {integrity: sha512-LGhzyZ10XAqgNezPYk7O7oXuU2/hO2FqjYdapMgk6axVxjvvq4i/mVZosSNa5POCBZOZNnGUt+PRIcGK6BicXg==}
 
   '@rolldown/binding-android-arm64@1.0.1':
     resolution: {integrity: sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==}
@@ -921,9 +924,6 @@ packages:
   effect@4.0.0-beta.107:
     resolution: {integrity: sha512-OoBAv8eF+yanc+C6xhgEUnWeXUSHA6ynnscYqpkAY9GSnzZWystsIjBowVqCkLpHGlnRtdIqYT3wHwpOY6JDnQ==}
 
-  effect@4.0.0-beta.97:
-    resolution: {integrity: sha512-pK03HpQVxGZOWdwDAy/iwvV8u3KYcUf2mOWyWqaut2zau8V2u6ejWP7b4BELjyUIiZWW1fl/s/VJpgZUcTjThg==}
-
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -994,9 +994,6 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
-
-  find-my-way-ts@0.1.6:
-    resolution: {integrity: sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==}
 
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
@@ -1090,6 +1087,10 @@ packages:
     resolution: {integrity: sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==}
     engines: {node: '>=0.10'}
 
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1103,10 +1104,6 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-
-  ini@7.0.0:
-    resolution: {integrity: sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==}
-    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   ioredis@5.10.1:
     resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
@@ -1321,18 +1318,17 @@ packages:
     resolution: {integrity: sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==}
     hasBin: true
 
-  msgpackr@2.0.4:
-    resolution: {integrity: sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA==}
-
   msgpackr@2.0.5:
     resolution: {integrity: sha512-cef05H/dSYpLpqp3sj/qyZh5vhUYCalnaLO7j1yOmpsR0y/XwLVtK7r5gn+U/F7CTEfMowcGhlUQJDLcLf7jcA==}
-
-  multipasta@0.2.8:
-    resolution: {integrity: sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q==}
 
   nanoid@3.3.16:
     resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  needle@3.5.0:
+    resolution: {integrity: sha512-jaQyPKKk2YokHrEg+vFDYxXIHTCBgiZwSHOoVx/8V3GIBS8/VN6NdVRmg8q1ERtPkMvmOvebsgga4sAj5hls/w==}
+    engines: {node: '>= 4.4.x'}
     hasBin: true
 
   node-gyp-build-optional-packages@5.2.2:
@@ -1479,8 +1475,8 @@ packages:
     resolution: {integrity: sha512-5G28I0eNCpKCv34f6jCNvY8e746RE4uTWisGBZSiUqyKnraN6NIZo5VimNWMBajICCAqzUjpqLmJN9q5KXq8mw==}
     hasBin: true
 
-  roku-deploy@3.17.7:
-    resolution: {integrity: sha512-aEgi9Vq8/D0NhJzY97CtEUUgUwfR0/F20QR/JIMKXKDxAYt8alfgV217WShTbnFMyYYnJflTMRCHP2bJBbriGQ==}
+  roku-deploy@3.18.2:
+    resolution: {integrity: sha512-O0nO/hzhax6nhcwsk40Vdoq7RKm4n3OCJfc+Vr5OcV1YfSg5qeFt6gY3RG74QjZ+KrTO1A51XO0Oe1e4qV4O8w==}
     hasBin: true
 
   rolldown@1.0.1:
@@ -1663,10 +1659,6 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
-
-  toml@4.1.2:
-    resolution: {integrity: sha512-m0vXfHODcw3gk+KONAOlVQ5yNHc3yS3B1ybM3HS1vqDoS0RWTDDVBVVTYi8hH0k+2OM1vmo9fb1WX9EVqjqfHA==}
-    engines: {node: '>=20'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -2060,20 +2052,20 @@ snapshots:
 
   '@aws/lambda-invoke-store@0.3.0': {}
 
-  '@effect/platform-node-shared@4.0.0-beta.101(effect@4.0.0-beta.97)':
+  '@effect/platform-node-shared@4.0.0-beta.107(effect@4.0.0-beta.107)':
     dependencies:
       '@types/ws': 8.18.1
-      effect: 4.0.0-beta.97
+      effect: 4.0.0-beta.107
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node@4.0.0-beta.97(effect@4.0.0-beta.97)(ioredis@5.10.1)':
+  '@effect/platform-node@4.0.0-beta.107(effect@4.0.0-beta.107)(ioredis@5.10.1(supports-color@7.2.0))':
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-beta.101(effect@4.0.0-beta.97)
-      effect: 4.0.0-beta.97
-      ioredis: 5.10.1
+      '@effect/platform-node-shared': 4.0.0-beta.107(effect@4.0.0-beta.107)
+      effect: 4.0.0-beta.107
+      ioredis: 5.10.1(supports-color@7.2.0)
       mime: 4.1.0
       undici: 8.8.0
     transitivePeerDependencies:
@@ -2160,21 +2152,26 @@ snapshots:
 
   '@putdotio/design@3.0.0': {}
 
-  '@putdotio/rokit@2.4.2(ioredis@5.10.1)':
+  '@putdotio/rokit@2.4.6(ioredis@5.10.1(supports-color@7.2.0))':
     dependencies:
-      '@effect/platform-node': 4.0.0-beta.97(effect@4.0.0-beta.97)(ioredis@5.10.1)
-      effect: 4.0.0-beta.97
+      '@effect/platform-node': 4.0.0-beta.107(effect@4.0.0-beta.107)(ioredis@5.10.1(supports-color@7.2.0))
+      '@effect/platform-node-shared': 4.0.0-beta.107(effect@4.0.0-beta.107)
+      effect: 4.0.0-beta.107
       jszip: 3.10.1
-      roku-deploy: 3.17.7
+      roku-deploy: 3.18.2
     transitivePeerDependencies:
       - bufferutil
       - ioredis
-      - supports-color
       - utf-8-validate
 
-  '@putdotio/vref@1.1.1':
+  '@putdotio/vref@1.2.4(ioredis@5.10.1(supports-color@7.2.0))':
     dependencies:
+      '@effect/platform-node': 4.0.0-beta.107(effect@4.0.0-beta.107)(ioredis@5.10.1(supports-color@7.2.0))
       effect: 4.0.0-beta.107
+    transitivePeerDependencies:
+      - bufferutil
+      - ioredis
+      - utf-8-validate
 
   '@resvg/resvg-js-android-arm-eabi@2.6.2':
     optional: true
@@ -2229,15 +2226,19 @@ snapshots:
 
   '@rokucommunity/bslib@0.1.1': {}
 
-  '@rokucommunity/bslint@0.8.44(brighterscript@0.73.0)':
+  '@rokucommunity/bslint@0.8.44(brighterscript@0.73.0(supports-color@7.2.0))':
     dependencies:
-      brighterscript: 0.73.0
+      brighterscript: 0.73.0(supports-color@7.2.0)
       fs-extra: 10.1.0
       jsonc-parser: 2.3.1
       minimatch: 3.1.5
       yargs: 15.4.1
 
   '@rokucommunity/logger@0.4.0':
+    dependencies:
+      chalk: 4.1.2
+
+  '@rokucommunity/logger@0.4.2':
     dependencies:
       chalk: 4.1.2
 
@@ -2519,9 +2520,9 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  brighterscript-formatter@1.8.1:
+  brighterscript-formatter@1.8.1(supports-color@7.2.0):
     dependencies:
-      brighterscript: 0.73.0
+      brighterscript: 0.73.0(supports-color@7.2.0)
       glob-all: 3.3.1
       jsonc-parser: 3.3.1
       source-map: 0.7.4
@@ -2529,7 +2530,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brighterscript@0.73.0:
+  brighterscript@0.73.0(supports-color@7.2.0):
     dependencies:
       '@rokucommunity/bslib': 0.1.1
       '@rokucommunity/logger': 0.4.0
@@ -2546,7 +2547,7 @@ snapshots:
       lodash.isequal: 4.5.0
       micromatch: 4.0.8
       require-relative: 0.8.7
-      roku-deploy: 3.17.6
+      roku-deploy: 3.17.6(supports-color@7.2.0)
       semver: 7.8.5
       source-map: 0.7.6
       thenby: 1.4.1
@@ -2661,9 +2662,11 @@ snapshots:
 
   debounce-promise@3.1.2: {}
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@7.2.0):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 7.2.0
 
   decamelize@1.2.0: {}
 
@@ -2691,19 +2694,6 @@ snapshots:
       kubernetes-types: 1.30.0
       msgpackr: 2.0.5
       uuid: 14.0.1
-
-  effect@4.0.0-beta.97:
-    dependencies:
-      '@standard-schema/spec': 1.1.0
-      fast-check: 4.9.0
-      find-my-way-ts: 0.1.6
-      ini: 7.0.0
-      kubernetes-types: 1.30.0
-      msgpackr: 2.0.4
-      multipasta: 0.2.8
-      toml: 4.1.2
-      uuid: 14.0.1
-      yaml: 2.9.0
 
   emoji-regex@8.0.0: {}
 
@@ -2763,8 +2753,6 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
-
-  find-my-way-ts@0.1.6: {}
 
   find-up@4.1.0:
     dependencies:
@@ -2873,6 +2861,10 @@ snapshots:
       jsprim: 2.0.2
       sshpk: 1.18.0
 
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ignore@5.3.2: {}
 
   immediate@3.0.6: {}
@@ -2884,13 +2876,11 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ini@7.0.0: {}
-
-  ioredis@5.10.1:
+  ioredis@5.10.1(supports-color@7.2.0):
     dependencies:
       '@ioredis/commands': 1.5.1
       cluster-key-slot: 1.1.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       denque: 2.1.0
       lodash.defaults: 4.2.0
       lodash.isarguments: 3.1.0
@@ -3072,17 +3062,16 @@ snapshots:
       '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.4
     optional: true
 
-  msgpackr@2.0.4:
-    optionalDependencies:
-      msgpackr-extract: 3.0.4
-
   msgpackr@2.0.5:
     optionalDependencies:
       msgpackr-extract: 3.0.4
 
-  multipasta@0.2.8: {}
-
   nanoid@3.3.16: {}
+
+  needle@3.5.0:
+    dependencies:
+      iconv-lite: 0.6.3
+      sax: 1.6.0
 
   node-gyp-build-optional-packages@5.2.2:
     dependencies:
@@ -3144,7 +3133,7 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postman-request@2.88.1-postman.48:
+  postman-request@2.88.1-postman.48(supports-color@7.2.0):
     dependencies:
       '@postman/form-data': 3.1.1
       '@postman/tough-cookie': 4.1.3-postman.1
@@ -3163,7 +3152,7 @@ snapshots:
       oauth-sign: 0.9.0
       qs: 6.14.2
       safe-buffer: 5.2.1
-      socks-proxy-agent: 8.0.5
+      socks-proxy-agent: 8.0.5(supports-color@7.2.0)
       stream-length: 1.0.2
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -3219,7 +3208,7 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  roku-deploy@3.17.6:
+  roku-deploy@3.17.6(supports-color@7.2.0):
     dependencies:
       '@types/request': 2.48.13
       chalk: 2.4.2
@@ -3234,16 +3223,16 @@ snapshots:
       micromatch: 4.0.8
       moment: 2.30.1
       parse-ms: 2.1.0
-      postman-request: 2.88.1-postman.48
+      postman-request: 2.88.1-postman.48(supports-color@7.2.0)
       semver: 7.8.5
       temp-dir: 2.0.0
       xml2js: 0.5.0
     transitivePeerDependencies:
       - supports-color
 
-  roku-deploy@3.17.7:
+  roku-deploy@3.18.2:
     dependencies:
-      '@types/request': 2.48.13
+      '@rokucommunity/logger': 0.4.2
       chalk: 2.4.2
       fast-glob: 3.3.3
       fs-extra: 7.0.1
@@ -3251,12 +3240,10 @@ snapshots:
       jsonc-parser: 2.3.1
       jszip: 3.10.1
       micromatch: 4.0.8
+      needle: 3.5.0
       picomatch: 2.3.2
-      postman-request: 2.88.1-postman.48
       semver: 7.8.5
       xml2js: 0.5.0
-    transitivePeerDependencies:
-      - supports-color
 
   rolldown@1.0.1:
     dependencies:
@@ -3329,10 +3316,10 @@ snapshots:
 
   smart-buffer@4.2.0: {}
 
-  socks-proxy-agent@8.0.5:
+  socks-proxy-agent@8.0.5(supports-color@7.2.0):
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       socks: 2.8.9
     transitivePeerDependencies:
       - supports-color
@@ -3450,8 +3437,6 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
-
-  toml@4.1.2: {}
 
   tslib@2.8.1: {}
 
@@ -3608,7 +3593,8 @@ snapshots:
 
   yallist@4.0.0: {}
 
-  yaml@2.9.0: {}
+  yaml@2.9.0:
+    optional: true
 
   yargs-parser@18.1.3:
     dependencies:


### PR DESCRIPTION
Update rokit to 2.4.6 and vref to 1.2.4, then rebuild the existing 19-image gallery with exact filter identities. The released rokit includes bounded waits and aligned runtime dependencies; the gallery keeps its authored screenshots, titles and labels.

Verification passed: `pnpm verify`, `pnpm roku test-live` (62 tests), `pnpm artifact`, real Chromium group/tag filters, keyboard/modal behavior, a 390px layout and reduced motion. Installed rokit cancellation also passed through the application's SceneGraph wrapper with a synthetic stalled request. Independent review is clean at `3615991`. Packaging used the documented system-font fallback.

Installed-consumer and gallery proof pass for this development-tooling update. Representative Roku device acceptance of successful queries and waits under the new deadlines remains a follow-up. No physical-device operations were run. The separate screenshot-validation draft is excluded.
