### PR TITLE
feat(telemetry): report playback failures to Sentry and fix the error dialog overflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,7 @@ PUTIO_TEST_PASSWORD=""
 PUTIO_TEST_TOTP_REFERENCE=""
 PUTIO_CLIENT_ID_FIRST_PARTY=""
 PUTIO_CLIENT_SECRET_FIRST_PARTY=""
+
+# Optional public Sentry DSN for local packaging. Release builds set it from the
+# PUTIO_ROKU_SENTRY_DSN repository variable; leave it empty to disable reporting.
+PUTIO_ROKU_SENTRY_DSN=""

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,6 +142,7 @@ jobs:
             conventional-changelog-conventionalcommits@9.1.0
         env:
           GITHUB_TOKEN: ${{ steps.release-bot.outputs.token }}
+          PUTIO_ROKU_SENTRY_DSN: ${{ vars.PUTIO_ROKU_SENTRY_DSN }}
           GIT_AUTHOR_NAME: ${{ steps.release-bot.outputs.app-slug }}[bot]
           GIT_AUTHOR_EMAIL: ${{ steps.release-bot-identity.outputs.user_id }}+${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com
           GIT_COMMITTER_NAME: ${{ steps.release-bot.outputs.app-slug }}[bot]
@@ -219,6 +220,7 @@ jobs:
         if: steps.release-target.outputs.state == 'draft'
         env:
           GH_TOKEN: ${{ steps.release-bot.outputs.token }}
+          PUTIO_ROKU_SENTRY_DSN: ${{ vars.PUTIO_ROKU_SENTRY_DSN }}
           RELEASE_TAG: ${{ steps.release-target.outputs.tag }}
           RELEASE_VERSION: ${{ steps.release-target.outputs.version }}
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@ env files are missing or stale and a maintainer supplied a SOPS payload, and
 - `pnpm verify` type-checks the live-test harness, checks Roku formatting, runs Roku static checks, and builds a fresh ZIP
 - `pnpm roku test-live` runs the Vitest contract tests for live-test flow wiring, fixture argument parsing, and Lab visual-capture registry drift
 - Roku static checks are configured through `bsconfig.json` and `bslint.json`
+- Runtime error reporting posts Sentry envelopes directly from `SentryTask`; the DSN is compiled in from `PUTIO_ROKU_SENTRY_DSN` at packaging time and stays empty in git, so local builds report nothing. Playback failures follow the `playback_failure` telemetry contract in [Roku variants and Lab](./docs/ROKU_VARIANTS.md#error-reporting)
 - Roku layout is authored in 1920x1080 FHD coordinates even when device screenshots are 1280x720; use `components/shared/UiMetrics/UiMetrics.brs` for shared screen, centering, row, and 3px autoscale-grid values instead of scattering raw modal/list dimensions
 - Headless Roku control uses `@putdotio/rokit` for generic Roku ECP/SceneGraph primitives and `scripts/roku-live-test.ts` for app-specific playback scenarios
 - Live app regressions are grouped as flow suites: use `pnpm roku live-test-flow-smoke` for auth/files/dialogs/settings/get-new-code coverage and `pnpm roku live-test-flow-full` before shipping broad routing/player/image refactors

--- a/components/App.xml
+++ b/components/App.xml
@@ -20,5 +20,7 @@
       id="appDialog"
       visible="false"
     />
+
+    <Group id="sentryTasks" />
   </children>
 </component>

--- a/components/lab/Lab.brs
+++ b/components/lab/Lab.brs
@@ -56,6 +56,14 @@ sub init()
             component: "appDialog",
         },
         {
+            id: "app-dialog-playback-error",
+            title: "AppDialog / playback error",
+            listTitle: "App / playback error",
+            section: "Dialogs",
+            description: "Playback failure with a long Roku errorMsg, source and code details, and the Settings hint. Every line must stay visible; nothing may abbreviate.",
+            component: "appDialog",
+        },
+        {
             id: "delete-dialog-short",
             title: "DeleteFileDialog / short file",
             listTitle: "Delete / short",
@@ -400,6 +408,8 @@ sub renderStory(index as integer)
         renderAppDialogStory("Exit put.io?", "", ["OK", "Cancel"], 1)
     else if story.id = "app-dialog-message"
         renderAppDialogStory("Settings not saved", "Video playback type could not be saved. Please try again.", ["OK"], 0)
+    else if story.id = "app-dialog-playback-error"
+        renderAppDialogStory("Playback failed", buildPlaybackErrorDialogMessage("HLS playlist download failed: could not load segment after 3 retries", "HLS", "-1"), ["OK"], 0)
     else if story.id = "delete-dialog-short"
         renderDeleteDialogStory("Sintel.mp4")
     else if story.id = "delete-dialog-long"

--- a/components/lab/Lab.xml
+++ b/components/lab/Lab.xml
@@ -10,6 +10,7 @@
   <script type="text/brightscript" uri="pkg:/source/BuildConfig.brs" />
   <script type="text/brightscript" uri="pkg:/components/shared/DialogStyle/DialogStyle.brs" />
   <script type="text/brightscript" uri="pkg:/components/shared/KeyUtils.brs" />
+  <script type="text/brightscript" uri="pkg:/components/shared/PlaybackErrorMessage.brs" />
   <script type="text/brightscript" uri="pkg:/components/lab/Lab.brs" />
 
   <children>

--- a/components/screens/Video/Video.brs
+++ b/components/screens/Video/Video.brs
@@ -51,7 +51,7 @@ end sub
 sub fetchFile(fileId)
     m.phase = "loadingFile"
     m.fetchFileTask.observeField("response", "onFetchFileResponse")
-    m.fetchFileTask.url = ("/files/list?parent_id=" + fileId.toStr() + "&mp4_status_parent=1&stream_url_parent=1&mp4_stream_url_parent=1&video_metadata_parent=1")
+    m.fetchFileTask.url = ("/files/list?parent_id=" + fileId.toStr() + "&mp4_status_parent=1&stream_url_parent=1&mp4_stream_url_parent=1&video_metadata_parent=1&media_info_parent=1&codecs_parent=1")
     m.fetchFileTask.method = "GET"
     m.fetchFileTask.control = "RUN"
 end sub
@@ -66,8 +66,39 @@ sub onFetchFileResponse(obj)
         handleFetchedFile()
     else
         hideLoading()
+        reportFetchFileFailure(data)
         showFetchFileErrorDialog(data)
     end if
+end sub
+
+sub reportFetchFileFailure(data)
+    if sentryIsEnabled() = false
+        return
+    end if
+
+    errorType = "none"
+    errorMessage = ""
+    if data <> invalid
+        if data.error_type <> invalid
+            errorType = data.error_type.toStr()
+        end if
+        if data.error_message <> invalid
+            errorMessage = data.error_message.toStr()
+        end if
+    end if
+
+    event = sentryCreateEvent("Roku video file request failed: " + errorType, "error")
+    event.fingerprint = ["roku-video-fetch-error", "error-type:" + errorType]
+    sentryAddTags(event, {
+        telemetry_event: "playback_source_request_failure",
+        source_request_error_type: errorType,
+    })
+    sentryAddExtra(event, {
+        file_id: m.top.params.fileId,
+        error_type: errorType,
+        error_message: errorMessage,
+    })
+    sentryCaptureEvent(event)
 end sub
 
 sub handleFetchedFile()

--- a/components/screens/Video/Video.xml
+++ b/components/screens/Video/Video.xml
@@ -6,6 +6,8 @@
   <script type="text/brightscript" uri="pkg:/components/shared/PlaybackConfig.brs" />
   <script type="text/brightscript" uri="pkg:/components/shared/PlaybackUtils.brs" />
   <script type="text/brightscript" uri="pkg:/components/shared/KeyUtils.brs" />
+  <script type="text/brightscript" uri="pkg:/source/BuildConfig.brs" />
+  <script type="text/brightscript" uri="pkg:/components/shared/Sentry/Sentry.brs" />
   <script type="text/brightscript" uri="pkg:/components/screens/Video/Video.brs" />
 
 	<interface>

--- a/components/screens/VideoPlayer/VideoPlayer.brs
+++ b/components/screens/VideoPlayer/VideoPlayer.brs
@@ -152,6 +152,8 @@ function init()
     m.errorDialog = invalid
     m.errorDialogShown = false
     m.currentStreamInfo = invalid
+    m.playbackStarted = false
+    m.playbackAttemptTimer = CreateObject("roTimespan")
 end function
 
 sub applyPlayerColors()
@@ -310,6 +312,8 @@ sub resetPlaybackState()
     m.errorDialog = invalid
     m.errorDialogShown = false
     m.currentStreamInfo = invalid
+    m.playbackStarted = false
+    m.playbackAttemptTimer = CreateObject("roTimespan")
     m.lastSavedVideoTime = invalid
     m.resumeSaveTimer = CreateObject("roTimespan")
     resetSeekPressTimer()
@@ -406,6 +410,10 @@ sub onPlayerStateChanged(obj)
 
     if state = "playing" or state = "buffering"
         enforcePlaybackSpeed()
+    end if
+
+    if state = "playing"
+        m.playbackStarted = true
     end if
 
     updatePlayIcon()
@@ -1318,11 +1326,30 @@ sub handlePlaybackError()
     m.hasPlaybackError = true
     updateBufferingOverlay(false)
     m.osdTimer.control = "stop"
+    reportPlaybackFailure()
     m.video.control = "stop"
 
     if m.errorDialogShown = false
         showPlaybackErrorDialog()
     end if
+end sub
+
+' Reads the Video node before control = "stop" clears errorInfo, then hands off to a task.
+sub reportPlaybackFailure()
+    if m.errorDialogShown or sentryIsEnabled() = false
+        return
+    end if
+
+    sentryCaptureEvent(createPlaybackFailureEvent({
+        video: m.video,
+        file: m.top.params.file,
+        streamInfo: m.currentStreamInfo,
+        playbackType: getConfiguredPlaybackType(),
+        playbackStarted: m.playbackStarted,
+        position: getDisplayedPosition(),
+        duration: m.duration,
+        timeToErrorMs: m.playbackAttemptTimer.totalMilliseconds(),
+    }))
 end sub
 
 function hasVideoErrorInfo() as boolean
@@ -1348,23 +1375,7 @@ sub showPlaybackErrorDialog()
 end sub
 
 function getPlaybackErrorDialogMessage() as string
-    message = getSafeVideoErrorMessage()
-    if message = ""
-        message = "Roku could not play this video."
-    end if
-
-    sourceLabel = getCurrentPlaybackSourceLabel()
-    if sourceLabel <> ""
-        message = message + chr(10) + "Source: " + sourceLabel
-    end if
-
-    code = getSafeVideoErrorCode()
-    if code <> ""
-        message = message + chr(10) + "Roku error code: " + code
-    end if
-
-    message = message + chr(10) + chr(10) + "Try another video playback type in Settings if this keeps happening."
-    return message
+    return buildPlaybackErrorDialogMessage(getSafeVideoErrorMessage(), getCurrentPlaybackSourceLabel(), getSafeVideoErrorCode())
 end function
 
 function getSafeVideoErrorMessage() as string

--- a/components/screens/VideoPlayer/VideoPlayer.xml
+++ b/components/screens/VideoPlayer/VideoPlayer.xml
@@ -5,9 +5,12 @@
   <script type="text/brightscript" uri="pkg:/components/shared/DialogStyle/DialogStyle.brs" />
   <script type="text/brightscript" uri="pkg:/components/shared/PlaybackConfig.brs" />
   <script type="text/brightscript" uri="pkg:/components/shared/PlaybackUtils.brs" />
+  <script type="text/brightscript" uri="pkg:/components/shared/PlaybackErrorMessage.brs" />
   <script type="text/brightscript" uri="pkg:/components/shared/KeyUtils.brs" />
   <script type="text/brightscript" uri="pkg:/components/screens/VideoPlayer/VideoPlayerTrackMenu.brs" />
   <script type="text/brightscript" uri="pkg:/source/BuildConfig.brs" />
+  <script type="text/brightscript" uri="pkg:/components/shared/Sentry/Sentry.brs" />
+  <script type="text/brightscript" uri="pkg:/components/shared/Sentry/PlaybackTelemetry.brs" />
   <script type="text/brightscript" uri="pkg:/components/shared/Typography/Typography.brs" />
   <script type="text/brightscript" uri="pkg:/components/screens/VideoPlayer/VideoPlayer.brs" />
 

--- a/components/shared/AppDialog/AppDialog.brs
+++ b/components/shared/AppDialog/AppDialog.brs
@@ -15,7 +15,7 @@ sub initAppDialog()
     m.titleLabel = m.top.findNode("titleLabel")
     m.divider = m.top.findNode("divider")
     m.messageLabels = []
-    for i = 0 to 5
+    for i = 0 to 7
         m.messageLabels.push(m.top.findNode("messageLine" + i.toStr()))
     end for
     m.buttonsGroup = m.top.findNode("buttonsGroup")
@@ -293,7 +293,8 @@ end sub
 
 function wrapAppDialogMessageLines(message as string, maxLineLength as integer) as object
     lines = []
-    maxLines = 6
+    ' 8 body lines plus two buttons is 807px in FHD; anything taller crowds the 1080 frame.
+    maxLines = 8
 
     if message = invalid or message = ""
         return lines
@@ -355,7 +356,8 @@ sub appendWrappedAppDialogLines(lines as object, text as string, maxLineLength a
         end if
     end while
 
-    if (remaining <> "" or hasMoreText) and lines.count() > 0
+    ' Only a hard line cap truncates; a paragraph followed by more text is not cut off.
+    if lines.count() >= maxLines and (remaining <> "" or hasMoreText)
         lines[lines.count() - 1] = abbreviateAppDialogLine(lines[lines.count() - 1], maxLineLength)
     end if
 end sub

--- a/components/shared/AppDialog/AppDialog.xml
+++ b/components/shared/AppDialog/AppDialog.xml
@@ -140,6 +140,24 @@
         visible="false"
       />
 
+      <Label
+        id="messageLine6"
+        translation="[48,432]"
+        width="804"
+        height="45"
+        horizAlign="center"
+        visible="false"
+      />
+
+      <Label
+        id="messageLine7"
+        translation="[48,480]"
+        width="804"
+        height="45"
+        horizAlign="center"
+        visible="false"
+      />
+
       <Group id="buttonsGroup" translation="[48,135]">
         <Group id="button0">
           <Rectangle

--- a/components/shared/PlaybackErrorMessage.brs
+++ b/components/shared/PlaybackErrorMessage.brs
@@ -1,0 +1,24 @@
+' AppDialog shows at most 8 body lines and abbreviates the rest, so the source, code,
+' and the action hint share as few lines as possible and the hint stays last but short.
+function buildPlaybackErrorDialogMessage(errorMessage as string, sourceLabel as string, errorCode as string) as string
+    message = errorMessage
+    if message = ""
+        message = "Roku could not play this video."
+    end if
+
+    details = ""
+    if sourceLabel <> ""
+        details = "Source: " + sourceLabel
+    end if
+    if errorCode <> ""
+        if details <> ""
+            details = details + "  |  "
+        end if
+        details = details + "Roku error " + errorCode
+    end if
+    if details <> ""
+        message = message + chr(10) + details
+    end if
+
+    return message + chr(10) + chr(10) + "Try another playback type in Settings."
+end function

--- a/components/shared/Sentry/PlaybackTelemetry.brs
+++ b/components/shared/Sentry/PlaybackTelemetry.brs
@@ -1,0 +1,323 @@
+' Builds the Sentry event for a terminal Roku playback failure. Mirrors the
+' putio-web `playback_failure` telemetry contract (schema_version 1) so one Sentry
+' search covers every put.io player: tags group and filter, extra carries detail.
+function createPlaybackFailureEvent(input as object) as object
+    video = input.video
+    errorCode = sentryVideoErrorCode(video)
+    errorMessage = sentryVideoErrorMessage(video)
+    errorInfo = sentryVideoErrorInfo(video)
+    failureMode = classifyRokuPlaybackFailure(errorCode, errorInfo)
+    streamInfo = input.streamInfo
+    file = input.file
+    sourceKind = sentryPlaybackSourceKind(streamInfo)
+    videoStream = sentryFileVideoStream(file)
+    audioStream = sentryFileAudioStream(file)
+
+    title = "Roku playback failed"
+    if errorMessage <> ""
+        title = title + ": " + errorMessage
+    end if
+
+    event = sentryCreateEvent(title, "error")
+    event.fingerprint = ["roku-playback-error", "failure:" + failureMode, "roku-code:" + errorCode]
+
+    sentryAddTags(event, {
+        telemetry_event: "playback_failure",
+        schema_version: "1",
+        player: "roku",
+        playback_outcome: "failed",
+        playback_terminal: "true",
+        playback_failure_mode: failureMode,
+        playback_started: input.playbackStarted,
+        playback_type: input.playbackType,
+        roku_error_code: errorCode,
+        roku_error_category: sentryErrorInfoField(errorInfo, "category"),
+        roku_error_source: sentryErrorInfoField(errorInfo, "source"),
+        source_kind: sourceKind,
+        stream_format: sentryStreamFormat(streamInfo),
+        file_id: sentryFileId(file),
+        file_extension: sentryFileExtension(file),
+        container_family: sentryContainerFamily(file),
+        video_codec: sentryStreamField(videoStream, "codec_name"),
+        video_profile: sentryStreamField(videoStream, "profile"),
+        video_resolution: sentryVideoResolution(videoStream),
+        video_pixel_format: sentryStreamField(videoStream, "pix_fmt"),
+        audio_codec: sentryStreamField(audioStream, "codec_name"),
+    })
+
+    sentryAddExtra(event, {
+        telemetry_event: "playback_failure",
+        schema_version: 1,
+        terminal: true,
+        file_id: sentryFileId(file),
+        file_name: sentryFileName(file),
+        file_size: sentryFileSize(file),
+        playback_started: input.playbackStarted,
+        playback_type: input.playbackType,
+        current_time_seconds: input.position,
+        duration_seconds: input.duration,
+        time_to_error_ms: input.timeToErrorMs,
+        video_state: sentryVideoState(video),
+        roku_error_code: errorCode,
+        roku_error_message: errorMessage,
+        roku_error_str: sentryVideoErrorStr(video),
+        roku_error_info: errorInfo,
+        stream_url: sentryRedactStreamUrl(streamInfo),
+        stream_format: sentryStreamFormat(streamInfo),
+        source_kind: sourceKind,
+        has_mp4_stream: sentryHasMp4Stream(file),
+        has_direct_stream: sentryHasDirectStream(file),
+        need_convert: sentryFileField(file, "need_convert"),
+        mp4_status: sentryMp4Status(file),
+        video_metadata: sentryFileField(file, "video_metadata"),
+        media_info: sentryFileField(file, "media_info"),
+    })
+
+    return event
+end function
+
+' Roku Video.errorCode: -1 network, -2 connection timed out, -3 unknown, -4 empty
+' playlist, -5 media/format error, -6 DRM. errorInfo.category refines it on OS 9+.
+function classifyRokuPlaybackFailure(errorCode as string, errorInfo as object) as string
+    category = LCase(sentryErrorInfoField(errorInfo, "category"))
+
+    if category = "http" or category = "network"
+        return "network"
+    else if category = "drm"
+        return "drm"
+    else if category = "mediaerror"
+        return "decode"
+    end if
+
+    if errorCode = "-1" or errorCode = "-2"
+        return "network"
+    else if errorCode = "-4"
+        return "load"
+    else if errorCode = "-5"
+        return "unsupported_source"
+    else if errorCode = "-6"
+        return "drm"
+    else if errorCode = "-3" or errorCode = "none"
+        return "unknown"
+    end if
+
+    return "unknown"
+end function
+
+function sentryVideoErrorCode(video as object) as string
+    if video <> invalid and video.errorCode <> invalid and video.errorCode.toStr() <> "" and video.errorCode.toStr() <> "0"
+        return video.errorCode.toStr()
+    end if
+
+    return "none"
+end function
+
+function sentryVideoErrorMessage(video as object) as string
+    if video <> invalid and video.errorMsg <> invalid and video.errorMsg.toStr() <> ""
+        return video.errorMsg.toStr()
+    end if
+
+    return ""
+end function
+
+function sentryVideoErrorStr(video as object) as string
+    if video <> invalid and video.hasField("errorStr") and video.errorStr <> invalid
+        return video.errorStr.toStr()
+    end if
+
+    return ""
+end function
+
+function sentryVideoErrorInfo(video as object) as object
+    if video <> invalid and video.hasField("errorInfo") and video.errorInfo <> invalid and type(video.errorInfo) = "roAssociativeArray"
+        return video.errorInfo
+    end if
+
+    return invalid
+end function
+
+function sentryVideoState(video as object) as string
+    if video <> invalid and video.state <> invalid
+        return video.state.toStr()
+    end if
+
+    return "unknown"
+end function
+
+function sentryErrorInfoField(errorInfo as object, key as string) as string
+    if errorInfo <> invalid and errorInfo[key] <> invalid
+        return sentryTagValue(errorInfo[key])
+    end if
+
+    return "none"
+end function
+
+function sentryPlaybackSourceKind(streamInfo as object) as string
+    if streamInfo = invalid or streamInfo.url = invalid
+        return "unknown"
+    end if
+
+    url = LCase(streamInfo.url.toStr())
+    if Instr(1, url, "/hls/") > 0 or Instr(1, url, ".m3u8") > 0
+        return "hls"
+    else if Instr(1, url, "/stream/") > 0
+        return "direct"
+    end if
+
+    return "mp4"
+end function
+
+function sentryStreamFormat(streamInfo as object) as string
+    if streamInfo <> invalid and streamInfo.format <> invalid
+        return LCase(streamInfo.format.toStr())
+    end if
+
+    return "unknown"
+end function
+
+' Stream URLs embed the download token as a query param; keep only the path.
+function sentryRedactStreamUrl(streamInfo as object) as string
+    if streamInfo = invalid or streamInfo.url = invalid
+        return ""
+    end if
+
+    url = streamInfo.url.toStr()
+    queryIndex = Instr(1, url, "?")
+    if queryIndex > 0
+        return Left(url, queryIndex - 1) + "?<redacted>"
+    end if
+
+    return url
+end function
+
+function sentryFileField(file as object, key as string) as dynamic
+    if file <> invalid and file[key] <> invalid
+        return file[key]
+    end if
+
+    return invalid
+end function
+
+function sentryFileId(file as object) as string
+    id = sentryFileField(file, "id")
+    if id = invalid
+        return "unknown"
+    end if
+
+    return id.toStr()
+end function
+
+function sentryFileName(file as object) as string
+    name = sentryFileField(file, "name")
+    if name = invalid
+        return ""
+    end if
+
+    return name.toStr()
+end function
+
+function sentryFileSize(file as object) as dynamic
+    return sentryFileField(file, "size")
+end function
+
+function sentryFileExtension(file as object) as string
+    extension = sentryFileField(file, "extension")
+    if extension = invalid or extension.toStr() = ""
+        return "unknown"
+    end if
+
+    return LCase(extension.toStr())
+end function
+
+function sentryContainerFamily(file as object) as string
+    candidates = []
+    contentType = sentryFileField(file, "content_type")
+    if contentType <> invalid
+        candidates.push(LCase(contentType.toStr()))
+    end if
+    mediaInfo = sentryFileField(file, "media_info")
+    if mediaInfo <> invalid and mediaInfo.format <> invalid and mediaInfo.format.format_name <> invalid
+        candidates.push(LCase(mediaInfo.format.format_name.toStr()))
+    end if
+    candidates.push(sentryFileExtension(file))
+
+    for each candidate in candidates
+        if Instr(1, candidate, "matroska") > 0 or candidate = "mkv"
+            return "matroska"
+        else if Instr(1, candidate, "webm") > 0
+            return "webm"
+        else if Instr(1, candidate, "mp4") > 0 or Instr(1, candidate, "m4v") > 0
+            return "mp4"
+        else if Instr(1, candidate, "quicktime") > 0 or candidate = "mov"
+            return "quicktime"
+        else if Instr(1, candidate, "mpegts") > 0 or Instr(1, candidate, "mp2t") > 0 or candidate = "ts"
+            return "mpeg-ts"
+        else if Instr(1, candidate, "avi") > 0
+            return "avi"
+        end if
+    end for
+
+    return "unknown"
+end function
+
+function sentryFileMediaStream(file as object, codecType as string) as object
+    mediaInfo = sentryFileField(file, "media_info")
+    if mediaInfo = invalid or mediaInfo.streams = invalid
+        return invalid
+    end if
+
+    for each stream in mediaInfo.streams
+        if stream <> invalid and stream.codec_type <> invalid and stream.codec_type.toStr() = codecType
+            return stream
+        end if
+    end for
+
+    return invalid
+end function
+
+function sentryFileVideoStream(file as object) as object
+    return sentryFileMediaStream(file, "video")
+end function
+
+function sentryFileAudioStream(file as object) as object
+    return sentryFileMediaStream(file, "audio")
+end function
+
+function sentryStreamField(stream as object, key as string) as string
+    if stream = invalid or stream[key] = invalid
+        return "unknown"
+    end if
+
+    return LCase(sentryTagValue(stream[key]))
+end function
+
+function sentryVideoResolution(stream as object) as string
+    if stream = invalid
+        return "unknown"
+    end if
+
+    width = sentryStreamField(stream, "width")
+    height = sentryStreamField(stream, "height")
+    if width = "unknown" or height = "unknown"
+        return "unknown"
+    end if
+
+    return width + "x" + height
+end function
+
+function sentryHasMp4Stream(file as object) as boolean
+    return sentryFileField(file, "mp4_stream_url") <> invalid
+end function
+
+function sentryHasDirectStream(file as object) as boolean
+    return sentryFileField(file, "stream_url") <> invalid
+end function
+
+function sentryMp4Status(file as object) as dynamic
+    mp4Status = sentryFileField(file, "mp4_status")
+    if mp4Status <> invalid and mp4Status.status <> invalid
+        return mp4Status.status
+    end if
+
+    return mp4Status
+end function

--- a/components/shared/Sentry/Sentry.brs
+++ b/components/shared/Sentry/Sentry.brs
@@ -10,24 +10,46 @@ sub sentryCaptureEvent(event as object)
         return
     end if
 
-    if m.sentryTasks = invalid
-        m.sentryTasks = []
-    end if
-
-    ' Keep in-flight tasks referenced; an unreferenced Task node can be collected mid-request.
-    activeTasks = []
-    for each task in m.sentryTasks
-        if task.done = false
-            activeTasks.push(task)
-        end if
-    end for
-    m.sentryTasks = activeTasks
-
     task = createObject("roSGNode", "SentryTask")
+    task.id = "sentryTask"
     task.dsn = buildConfigSentryDsn()
     task.event = event
+    sentryRetainTask(task)
     task.control = "RUN"
-    m.sentryTasks.push(task)
+end sub
+
+' An unreferenced Task node can be collected mid-request, and the reporting screen is
+' popped as soon as its failure dialog closes, so in-flight tasks hang off the scene's
+' sentryTasks group rather than the screen. Finished tasks are pruned on the next capture.
+sub sentryRetainTask(task as object)
+    holder = invalid
+    scene = m.top.getScene()
+    if scene <> invalid
+        holder = scene.findNode("sentryTasks")
+    end if
+
+    if holder = invalid
+        if m.sentryTasks = invalid
+            m.sentryTasks = []
+        end if
+        activeTasks = []
+        for each activeTask in m.sentryTasks
+            if activeTask.done = false
+                activeTasks.push(activeTask)
+            end if
+        end for
+        activeTasks.push(task)
+        m.sentryTasks = activeTasks
+        return
+    end if
+
+    for i = holder.getChildCount() - 1 to 0 step -1
+        child = holder.getChild(i)
+        if child.done
+            holder.removeChildIndex(i)
+        end if
+    end for
+    holder.appendChild(task)
 end sub
 
 function sentryCreateEvent(message as string, level as string) as object

--- a/components/shared/Sentry/Sentry.brs
+++ b/components/shared/Sentry/Sentry.brs
@@ -1,0 +1,174 @@
+' Render-thread helpers for reporting to Sentry. Events are built here and handed to a
+' SentryTask so the screen never waits on the network. Reporting is a no-op unless the
+' package was built with a DSN (see PUTIO_ROKU_SENTRY_DSN in docs/ROKU_VARIANTS.md).
+function sentryIsEnabled() as boolean
+    return buildConfigSentryDsn() <> ""
+end function
+
+sub sentryCaptureEvent(event as object)
+    if event = invalid or sentryIsEnabled() = false
+        return
+    end if
+
+    if m.sentryTasks = invalid
+        m.sentryTasks = []
+    end if
+
+    ' Keep in-flight tasks referenced; an unreferenced Task node can be collected mid-request.
+    activeTasks = []
+    for each task in m.sentryTasks
+        if task.done = false
+            activeTasks.push(task)
+        end if
+    end for
+    m.sentryTasks = activeTasks
+
+    task = createObject("roSGNode", "SentryTask")
+    task.dsn = buildConfigSentryDsn()
+    task.event = event
+    task.control = "RUN"
+    m.sentryTasks.push(task)
+end sub
+
+function sentryCreateEvent(message as string, level as string) as object
+    deviceInfo = CreateObject("roDeviceInfo")
+    appInfo = CreateObject("roAppInfo")
+    appVersion = appInfo.getVersion()
+    osVersion = sentryFormatOsVersion(deviceInfo.getOSVersion())
+    model = deviceInfo.getModel()
+    modelName = deviceInfo.getModelDisplayName()
+    if modelName = invalid or modelName = ""
+        modelName = model
+    end if
+
+    event = {
+        event_id: sentryEventId(deviceInfo),
+        timestamp: CreateObject("roDateTime").asSeconds(),
+        platform: "other",
+        logger: "putio-roku",
+        level: level,
+        message: message,
+        release: "putio-roku@" + appVersion,
+        environment: buildConfigVariant(),
+        sdk: {
+            name: "putio-roku",
+            version: appVersion,
+        },
+        contexts: {
+            app: {
+                app_name: "put.io Roku",
+                app_version: appVersion,
+            },
+            device: {
+                family: "Roku",
+                model: model,
+                name: modelName,
+                model_id: model,
+                screen_resolution: deviceInfo.getVideoMode(),
+                connection_type: deviceInfo.getConnectionType(),
+            },
+            os: {
+                name: "Roku OS",
+                version: osVersion,
+            },
+        },
+        tags: {
+            roku_model: model,
+            roku_os: osVersion,
+            connection_type: deviceInfo.getConnectionType(),
+            video_mode: deviceInfo.getVideoMode(),
+        },
+        extra: {},
+    }
+
+    ' /account/info reports the id as user_id; older payloads used id.
+    if m.global <> invalid and m.global.hasField("user") and m.global.user <> invalid
+        if m.global.user.user_id <> invalid
+            event.user = { id: m.global.user.user_id.toStr() }
+        else if m.global.user.id <> invalid
+            event.user = { id: m.global.user.id.toStr() }
+        end if
+    end if
+
+    return event
+end function
+
+sub sentryAddTags(event as object, tags as object)
+    for each key in tags
+        event.tags[key] = sentryTagValue(tags[key])
+    end for
+end sub
+
+sub sentryAddExtra(event as object, extra as object)
+    for each key in extra
+        event.extra[key] = extra[key]
+    end for
+end sub
+
+' Sentry tags are short strings; anything else becomes "unknown"/"none" style text.
+function sentryTagValue(value) as string
+    if value = invalid
+        return "none"
+    end if
+
+    valueType = type(value)
+    if valueType = "roString" or valueType = "String"
+        if value = ""
+            return "none"
+        end if
+        if Len(value) > 200
+            return Left(value, 200)
+        end if
+        return value
+    end if
+
+    if valueType = "roBoolean" or valueType = "Boolean"
+        if value
+            return "true"
+        end if
+        return "false"
+    end if
+
+    if valueType = "roInt" or valueType = "Integer" or valueType = "roInteger" or valueType = "roFloat" or valueType = "Float" or valueType = "roDouble" or valueType = "Double" or valueType = "LongInteger" or valueType = "roLongInteger"
+        return value.toStr()
+    end if
+
+    return "unknown"
+end function
+
+function sentryEventId(deviceInfo as object) as string
+    uuid = deviceInfo.getRandomUUID()
+    eventId = ""
+    for i = 1 to Len(uuid)
+        char = Mid(uuid, i, 1)
+        if char <> "-"
+            eventId = eventId + LCase(char)
+        end if
+    end for
+
+    return eventId
+end function
+
+function sentryFormatOsVersion(osVersion as object) as string
+    if osVersion = invalid
+        return "unknown"
+    end if
+
+    parts = []
+    for each key in ["major", "minor", "revision", "build"]
+        if osVersion[key] <> invalid and osVersion[key].toStr() <> ""
+            parts.push(osVersion[key].toStr())
+        end if
+    end for
+
+    if parts.count() = 0
+        return "unknown"
+    end if
+
+    version = parts[0]
+    for i = 1 to parts.count() - 1
+        version = version + "." + parts[i]
+    end for
+
+    return version
+end function

--- a/components/shared/SentryTask/SentryTask.brs
+++ b/components/shared/SentryTask/SentryTask.brs
@@ -24,11 +24,9 @@ sub send()
     http = createObject("roUrlTransfer")
     http.setPort(port)
     http.retainBodyOnError(true)
-    ' Mirrors HttpTask: older Roku OS CA bundles reject some modern chains, and the
-    ' payload carries no credential worth protecting from an active attacker.
+    ' Events carry the user id and file names, so unlike HttpTask this keeps peer and
+    ' host verification on; a failed handshake drops the event instead of leaking it.
     http.setCertificatesFile("common:/certs/ca-bundle.crt")
-    http.enableHostVerification(false)
-    http.enablePeerVerification(false)
     http.initClientCertificates()
     http.setUrl(dsn.envelopeUrl)
     http.addHeader("Content-Type", "application/x-sentry-envelope")

--- a/components/shared/SentryTask/SentryTask.brs
+++ b/components/shared/SentryTask/SentryTask.brs
@@ -1,0 +1,109 @@
+sub init()
+    m.top.functionName = "send"
+end sub
+
+' Sentry has no BrightScript SDK, so this posts one event envelope over plain HTTPS.
+' The DSN only carries the public key; nothing here is a secret. Failures are dropped
+' silently: an unreachable ingest must never affect the screen that reported the error.
+sub send()
+    requestTimeoutMs = 10000
+    dsn = parseSentryDsn(m.top.dsn)
+    event = m.top.event
+
+    if dsn = invalid or event = invalid or event.event_id = invalid
+        m.top.done = true
+        return
+    end if
+
+    sentAt = CreateObject("roDateTime").ToISOString()
+    envelope = formatJSON({ event_id: event.event_id, sent_at: sentAt, dsn: m.top.dsn }) + chr(10)
+    envelope = envelope + formatJSON({ type: "event" }) + chr(10)
+    envelope = envelope + formatJSON(event) + chr(10)
+
+    port = createObject("roMessagePort")
+    http = createObject("roUrlTransfer")
+    http.setPort(port)
+    http.retainBodyOnError(true)
+    ' Mirrors HttpTask: older Roku OS CA bundles reject some modern chains, and the
+    ' payload carries no credential worth protecting from an active attacker.
+    http.setCertificatesFile("common:/certs/ca-bundle.crt")
+    http.enableHostVerification(false)
+    http.enablePeerVerification(false)
+    http.initClientCertificates()
+    http.setUrl(dsn.envelopeUrl)
+    http.addHeader("Content-Type", "application/x-sentry-envelope")
+    http.addHeader("X-Sentry-Auth", "Sentry sentry_version=7, sentry_client=" + sentryClientName(event) + ", sentry_key=" + dsn.publicKey)
+    http.setRequest("POST")
+
+    if http.asyncPostFromString(envelope)
+        msg = wait(requestTimeoutMs, port)
+        if type(msg) = "roUrlEvent"
+            m.top.responseCode = msg.getResponseCode()
+        else
+            http.asyncCancel()
+        end if
+    end if
+
+    m.top.done = true
+end sub
+
+function sentryClientName(event as object) as string
+    if event.sdk <> invalid and event.sdk.name <> invalid and event.sdk.version <> invalid
+        return event.sdk.name.toStr() + "/" + event.sdk.version.toStr()
+    end if
+
+    return "putio-roku/unknown"
+end function
+
+' DSN shape: https://<publicKey>@<host>/<projectId>. Returns invalid for anything else.
+function parseSentryDsn(dsn as string) as object
+    if dsn = invalid or dsn = ""
+        return invalid
+    end if
+
+    schemeEnd = Instr(1, dsn, "://")
+    if schemeEnd <= 0
+        return invalid
+    end if
+
+    scheme = Left(dsn, schemeEnd - 1)
+    remainder = Mid(dsn, schemeEnd + 3)
+    atIndex = Instr(1, remainder, "@")
+    if atIndex <= 1
+        return invalid
+    end if
+
+    publicKey = Left(remainder, atIndex - 1)
+    colonIndex = Instr(1, publicKey, ":")
+    if colonIndex > 0
+        publicKey = Left(publicKey, colonIndex - 1)
+    end if
+
+    hostAndPath = Mid(remainder, atIndex + 1)
+    slashIndex = Instr(1, hostAndPath, "/")
+    if slashIndex <= 1
+        return invalid
+    end if
+
+    host = Left(hostAndPath, slashIndex - 1)
+    path = Mid(hostAndPath, slashIndex)
+    lastSlash = 0
+    for i = Len(path) to 1 step -1
+        if Mid(path, i, 1) = "/"
+            lastSlash = i
+            exit for
+        end if
+    end for
+
+    projectId = Mid(path, lastSlash + 1)
+    basePath = Left(path, lastSlash - 1)
+    if projectId = "" or publicKey = ""
+        return invalid
+    end if
+
+    return {
+        publicKey: publicKey,
+        projectId: projectId,
+        envelopeUrl: scheme + "://" + host + basePath + "/api/" + projectId + "/envelope/",
+    }
+end function

--- a/components/shared/SentryTask/SentryTask.xml
+++ b/components/shared/SentryTask/SentryTask.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="SentryTask" extends="task">
+  <script type="text/brightscript" uri="pkg:/components/shared/SentryTask/SentryTask.brs" />
+
+  <interface>
+    <field id="dsn" type="string" />
+    <field id="event" type="assocarray" />
+    <field id="responseCode" type="integer" value="0" />
+    <field id="done" type="bool" value="false" alwaysNotify="true" />
+  </interface>
+</component>

--- a/components/shared/VideoConversionStatus/VideoConversionStatus.brs
+++ b/components/shared/VideoConversionStatus/VideoConversionStatus.brs
@@ -178,7 +178,7 @@ end sub
 
 sub refetchConvertedFile()
     m.fetchFileTask.observeField("response", "onFetchFileResponse")
-    m.fetchFileTask.url = ("/files/list?parent_id=" + m.top.fileId.toStr() + "&mp4_status_parent=1&stream_url_parent=1&mp4_stream_url_parent=1&video_metadata_parent=1")
+    m.fetchFileTask.url = ("/files/list?parent_id=" + m.top.fileId.toStr() + "&mp4_status_parent=1&stream_url_parent=1&mp4_stream_url_parent=1&video_metadata_parent=1&media_info_parent=1&codecs_parent=1")
     m.fetchFileTask.method = "GET"
     m.fetchFileTask.control = "RUN"
 end sub

--- a/docs/ROKU_VARIANTS.md
+++ b/docs/ROKU_VARIANTS.md
@@ -35,6 +35,8 @@ Variant selection happens at the packaging boundary:
 - `ROKU_VARIANT=production|development|lab`
 - `ROKU_APP_TITLE` overrides the variant title
 - `PUTIO_ROKU_APP_ID` sets the put.io OAuth/app id in the generated build config
+- `PUTIO_ROKU_SENTRY_DSN` compiles the public Sentry DSN into the build config;
+  unset or empty disables runtime error reporting (see [Error reporting](#error-reporting))
 
 [scripts/package-roku.ts](../scripts/package-roku.ts) renders the variant
 manifest and `source/BuildConfig.brs` as package-time overrides, then delegates
@@ -72,3 +74,30 @@ Normal builds use the installed package, not a sibling checkout.
   [UiMetrics.brs](../components/shared/UiMetrics/UiMetrics.brs).
 - Do not generate Roku-native token files inside `putio-design`; this repo owns
   the Roku adaptation.
+
+## Error reporting
+
+Sentry has no BrightScript SDK, so the app posts envelopes straight to the
+Sentry ingest API:
+
+- [components/shared/Sentry/Sentry.brs](../components/shared/Sentry/Sentry.brs)
+  builds events with release, environment, device, OS, and user context on the
+  render thread and hands each one to a
+  [SentryTask](../components/shared/SentryTask/SentryTask.brs), which POSTs it
+  from a Task thread; screens never wait on the network
+- [components/shared/Sentry/PlaybackTelemetry.brs](../components/shared/Sentry/PlaybackTelemetry.brs)
+  turns a terminal `Video` failure into a `playback_failure` event that mirrors
+  the putio-web telemetry contract (`schema_version` 1): tags for grouping such
+  as `playback_failure_mode`, `roku_error_code`, `source_kind`, `stream_format`,
+  `video_codec`, and `roku_model`, plus extra with Roku `errorInfo`, the
+  redacted stream URL, and the file `media_info`
+- `VideoPlayer` reports before it stops the Video node because `control = "stop"`
+  clears `errorInfo`; `Video` reports failed file requests separately
+- Reporting is a no-op unless the package was built with `PUTIO_ROKU_SENTRY_DSN`;
+  the checked-in `source/BuildConfig.brs` keeps it empty so open-source clones
+  and local builds send nothing. The release workflow sets it from the
+  `PUTIO_ROKU_SENTRY_DSN` repository variable. A DSN carries only the public key
+  and is safe to ship, but packaging rejects values that do not look like
+  `https://<publicKey>@<host>/<projectId>` so a typo cannot silently drop every
+  report
+

--- a/scripts/live-test/visual-capture.ts
+++ b/scripts/live-test/visual-capture.ts
@@ -31,6 +31,7 @@ export const visualLabStories = [
   ["screen-header", "ScreenHeader / branded title"],
   ["app-dialog-empty", "AppDialog / no message"],
   ["app-dialog-message", "AppDialog / message"],
+  ["app-dialog-playback-error", "AppDialog / playback error"],
   ["delete-dialog-short", "DeleteFileDialog / short file"],
   ["delete-dialog-long", "DeleteFileDialog / long file"],
   ["continue-watching", "ContinueWatchingPrompt"],
@@ -53,6 +54,7 @@ export type VisualLabStory = (typeof visualLabStories)[number];
 export const defaultVisualLabStoryIds = new Set<string>([
   "app-dialog-empty",
   "app-dialog-message",
+  "app-dialog-playback-error",
 ]);
 
 const labLaunchRetryCount = 24;

--- a/scripts/package-roku.ts
+++ b/scripts/package-roku.ts
@@ -10,6 +10,8 @@ export interface RokuPackageOptions {
   readonly outFile: string;
   readonly putioAppId?: string;
   readonly repoRoot: string;
+  // Public Sentry DSN compiled into the package. Empty disables reporting at runtime.
+  readonly sentryDsn?: string;
   readonly variant: RokuVariant;
 }
 
@@ -18,6 +20,7 @@ export interface RokuPackageResult {
   readonly fileCount: number;
   readonly files: readonly string[];
   readonly outFile: string;
+  readonly sentryEnabled: boolean;
   readonly title: string;
   readonly variant: RokuVariant;
 }
@@ -46,7 +49,7 @@ export async function packageRokuApp(options: RokuPackageOptions): Promise<RokuP
         path: "manifest",
       },
       {
-        contents: renderBuildConfig(options.variant, options.putioAppId ?? "3776", brandFontsBundled),
+        contents: renderBuildConfig(options.variant, options.putioAppId ?? "3776", brandFontsBundled, options.sentryDsn ?? ""),
         path: "source/BuildConfig.brs",
       },
     ],
@@ -59,6 +62,7 @@ export async function packageRokuApp(options: RokuPackageOptions): Promise<RokuP
     fileCount: result.fileCount,
     files: result.files,
     outFile,
+    sentryEnabled: validatedSentryDsn(options.sentryDsn ?? "") !== "",
     title,
     variant: options.variant,
   };
@@ -119,6 +123,7 @@ export function renderBuildConfig(
   variant: RokuVariant,
   putioAppId: string,
   brandFontsAvailable: boolean,
+  sentryDsn = "",
 ): string {
   return `function buildConfigVariant() as string
     return "${brightScriptString(variant)}"
@@ -135,7 +140,26 @@ end function
 function buildConfigBrandFontsAvailable() as boolean
     return ${brandFontsAvailable ? "true" : "false"}
 end function
+
+function buildConfigSentryDsn() as string
+    return "${brightScriptString(validatedSentryDsn(sentryDsn))}"
+end function
 `;
+}
+
+// A DSN carries only the public key, so it is safe to ship, but a typo would make every
+// report silently vanish: reject anything that is not https://<key>@<host>/<projectId>.
+export function validatedSentryDsn(value: string): string {
+  const dsn = value.trim();
+  if (dsn === "") {
+    return "";
+  }
+
+  if (!/^https:\/\/[A-Za-z0-9]+@[A-Za-z0-9.-]+(?::\d+)?(?:\/[A-Za-z0-9._-]+)*\/\d+$/.test(dsn)) {
+    throw new Error("PUTIO_ROKU_SENTRY_DSN must look like https://<publicKey>@<host>/<projectId>");
+  }
+
+  return dsn;
 }
 
 function shouldIncludeFile(relativePath: string, variant: RokuVariant): boolean {

--- a/scripts/roku-task/build.ts
+++ b/scripts/roku-task/build.ts
@@ -28,10 +28,14 @@ export async function packageRoku(config: VariantConfig): Promise<void> {
     outFile,
     putioAppId: process.env.PUTIO_ROKU_APP_ID,
     repoRoot,
+    sentryDsn: process.env.PUTIO_ROKU_SENTRY_DSN,
     variant: config.variant,
   });
   assertFile(outFile);
   console.log(`Packaged ${result.title} (${result.variant}) with ${result.fileCount} source files: ${result.outFile}`);
+  if (!result.sentryEnabled) {
+    console.log("Packaged without a Sentry DSN; runtime error reporting is disabled.");
+  }
   if (!result.brandFontsBundled) {
     console.log(
       "Packaged without licensed brand fonts; labels render in the Roku system font. Run pnpm roku fonts-setup to bundle GT America.",

--- a/scripts/roku-task/live.ts
+++ b/scripts/roku-task/live.ts
@@ -308,6 +308,7 @@ function storyTitle(story: string): string | undefined {
   const titles: Record<string, string> = {
     "app-dialog-empty": "AppDialog / no message",
     "app-dialog-message": "AppDialog / message",
+    "app-dialog-playback-error": "AppDialog / playback error",
     "continue-watching": "ContinueWatchingPrompt",
     "continue-watching-beginning": "ContinueWatchingPrompt / beginning",
     "conversion-status-converting": "VideoConversionStatus / converting",

--- a/source/BuildConfig.brs
+++ b/source/BuildConfig.brs
@@ -13,3 +13,7 @@ end function
 function buildConfigBrandFontsAvailable() as boolean
     return false
 end function
+
+function buildConfigSentryDsn() as string
+    return ""
+end function

--- a/test/live-test/roku-package.test.ts
+++ b/test/live-test/roku-package.test.ts
@@ -8,6 +8,7 @@ import {
   parseVariant,
   renderBuildConfig,
   renderVariantManifest,
+  validatedSentryDsn,
 } from "../../scripts/package-roku.ts";
 
 const repoRoot = process.cwd();
@@ -66,6 +67,19 @@ describe("Roku package variants", () => {
     expect(renderBuildConfig("production", "3776", false)).toContain(
       "function buildConfigBrandFontsAvailable() as boolean\n    return false",
     );
+  });
+
+  it("compiles the Sentry DSN into the build config and rejects malformed values", () => {
+    expect(renderBuildConfig("production", "3776", false)).toContain(
+      'function buildConfigSentryDsn() as string\n    return ""',
+    );
+    expect(
+      renderBuildConfig("production", "3776", false, "https://abc123@o804.ingest.us.sentry.io/4509999"),
+    ).toContain('return "https://abc123@o804.ingest.us.sentry.io/4509999"');
+    expect(validatedSentryDsn("  ")).toBe("");
+    expect(() => validatedSentryDsn("https://abc123@o804.ingest.us.sentry.io/")).toThrow("PUTIO_ROKU_SENTRY_DSN");
+    expect(() => validatedSentryDsn("abc123@o804.ingest.us.sentry.io/1")).toThrow("PUTIO_ROKU_SENTRY_DSN");
+    expect(() => validatedSentryDsn('https://a"b@host/1')).toThrow("PUTIO_ROKU_SENTRY_DSN");
   });
 
   it("writes a variant package ZIP", async () => {


### PR DESCRIPTION
## Problem

Playback failures on Roku never reach us. Batu reported new HLS playback issues and we had nothing to look at. Separately, the playback error dialog appended four lines and overflowed `AppDialog` on device, cutting off the action row.

## Solution

**Sentry over raw HTTP.** There is no BrightScript SDK, so `SentryTask` posts an envelope straight to the ingest API from a Task thread; screens never block. `PlaybackTelemetry.brs` mirrors the putio-web `playback_failure` contract (`schema_version` 1): tags for grouping (`playback_failure_mode`, `roku_error_code`, `roku_error_category`, `source_kind`, `stream_format`, `playback_type`, `video_codec`, `roku_model`, `roku_os`), extra with Roku `errorInfo`, the redacted stream URL, and the file `media_info`. `VideoPlayer` reports before `control = "stop"` clears `errorInfo`; `Video` reports failed file requests too.

The DSN is compiled in from `PUTIO_ROKU_SENTRY_DSN` at packaging time and stays empty in git, so open-source and local builds send nothing. Packaging rejects malformed DSNs. The release workflow reads the `PUTIO_ROKU_SENTRY_DSN` repository variable.

**Dialog fix.** Message compacted to one details line, `AppDialog` allows eight body lines, and the wrapper no longer appends `...` to every paragraph that has a successor (that was a latent bug). New Lab story `app-dialog-playback-error` covers the long-message case.

## Proof

- `pnpm verify` passes (63 Vitest tests, bsfmt, bslint, package).
- Transport proven end to end on the 3500X: dev build with a DSN pointing at a local HTTPS capture server, HLS URL patched to 404, deep-linked the playback fixture. Captured envelope had the correct `X-Sentry-Auth`, `/api/<project>/envelope/` path, and a full `playback_failure` event: `roku_error_code=-1`, `roku_error_category=http`, `errorInfo.dbgmsg="reader pick stream error:HTTP error:HTTP server returned error code"`, `user.id`, release `putio-roku@2.16.0`. The fetch-file path was proven the same way with a missing file id.
- Real ingest proven from the 3500X through the `relay.put.io` tunnel (Sentry ingest is TLS-reset by Turkish ISPs): deep-linked a missing file id with the production DSN compiled in, TLS peer and host verification on. Sentry issue 7717472312 in project `roku`, "Roku video file request failed: NotFound", carries `telemetry_event`, `source_request_error_type=NotFound`, device, OS, `user.id`, and release `putio-roku@2.16.0`.
- Lab story on device, all lines visible:

![AppDialog / playback error](https://attach.uinaf.dev/o/fG-IF3kYkewOzpe6y14rww)
