### PR TITLE
fix(files): restore wraparound navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ After installation, sign in with your put.io account to:
 - adjust app settings
 - stream supported media on Roku
 
+Long file lists wrap around: press Up on the first item to reach the last,
+or Down on the last item to return to the first.
+
 ## Docs
 
 - [Sideloading guide](./docs/SIDELOADING.md) for device setup and ZIP installation

--- a/components/screens/Files/Files.xml
+++ b/components/screens/Files/Files.xml
@@ -34,7 +34,7 @@
       drawFocusFeedback="true"
       drawFocusFeedbackOnTop="false"
       focusBitmapUri="pkg:/images/list-item-focus.9.png"
-      vertFocusAnimationStyle="fixedFocus"
+      vertFocusAnimationStyle="fixedFocusWrap"
       numRows="6"
     />
 

--- a/scripts/live-test/app-flows.ts
+++ b/scripts/live-test/app-flows.ts
@@ -15,6 +15,7 @@ import {
   assertNamedNodeHidden,
   assertNamedNodeVisible,
   hasVisibleComponent,
+  readListFocusIndex,
 } from "./scenegraph.ts";
 import { rokuDesignColor } from "./design-colors.ts";
 
@@ -183,6 +184,23 @@ async function filesNavigationFlowSmoke(
   console.log(`asserted files list is populated: ${fileCount} item(s)`);
 
   await driver.focusListItemByIndex(target, "fileList", 0);
+  if (fileCount > 6) {
+    await pressKey(target, "Up");
+    await waitForSceneGraphAssertion(target, "files wrap from first to last", (xml) => {
+      if (readListFocusIndex(xml, "fileList") !== fileCount - 1) {
+        throw new Error("expected Up from the first file to focus the last file");
+      }
+    });
+    await pressKey(target, "Down");
+    await waitForSceneGraphAssertion(target, "files wrap from last to first", (xml) => {
+      if (readListFocusIndex(xml, "fileList") !== 0) {
+        throw new Error("expected Down from the last file to focus the first file");
+      }
+    });
+    console.log("asserted files list wraps in both directions");
+  } else {
+    console.log("files wrap check skipped: requires more than six items");
+  }
   await pressKey(target, "Select");
   await driver.waitForAnyRouteScreenVisible(
     target,

--- a/scripts/live-test/app-flows.ts
+++ b/scripts/live-test/app-flows.ts
@@ -184,7 +184,8 @@ async function filesNavigationFlowSmoke(
   console.log(`asserted files list is populated: ${fileCount} item(s)`);
 
   await driver.focusListItemByIndex(target, "fileList", 0);
-  if (fileCount > 6) {
+  const visibleFileRows = 6;
+  if (fileCount > visibleFileRows) {
     await pressKey(target, "Up");
     await waitForSceneGraphAssertion(target, "files wrap from first to last", (xml) => {
       if (readListFocusIndex(xml, "fileList") !== fileCount - 1) {
@@ -199,7 +200,7 @@ async function filesNavigationFlowSmoke(
     });
     console.log("asserted files list wraps in both directions");
   } else {
-    console.log("files wrap check skipped: requires more than six items");
+    console.log(`files wrap check skipped: requires more than ${visibleFileRows} items`);
   }
   await pressKey(target, "Select");
   await driver.waitForAnyRouteScreenVisible(


### PR DESCRIPTION
Pressing Up on the first file stopped at the top, removing the shortcut to “Items shared with you.” Restore native file-list wrapping so Up reaches the last item and Down returns to the first. Short lists retain Roku’s native non-wrapping behavior.

Verified on a Roku Stick with 24 items: reverting the setting leaves Up at item 1; the fix moves it to item 24, and Down returns to item 1. Files open/Back and dialog focus flows passed. The files regression flow now checks both wrap directions.

[Before/after demo — labeled device screenshots](https://attach.uinaf.dev/p/ZHrc_54ltaGqyS58BkfyOA)
